### PR TITLE
Add RMB httpclient and test scripts

### DIFF
--- a/scripts/VMwithHttpClientTest.ts
+++ b/scripts/VMwithHttpClientTest.ts
@@ -122,7 +122,7 @@ async function main() {
         deployment.contract_id = 5;
         let payload = JSON.stringify(deployment);
 
-        let rmb = new HTTPMessageBusClient();
+        let rmb = new HTTPMessageBusClient("https://rmbproxy1.devnet.grid.tf");
         let msg = rmb.prepare("zos.deployment.deploy", [node_twin_id], 0, 2);
 
 

--- a/scripts/softHttpClientTest.ts
+++ b/scripts/softHttpClientTest.ts
@@ -1,0 +1,32 @@
+
+import { HTTPMessageBusClient } from "../src/rmb/httpClient"
+
+
+
+function delay(s: number) {
+    return new Promise( resolve => setTimeout(resolve, s*1000) );
+}
+
+async function main() {
+    const dstNodeId = 38;
+
+    async function deploy() {
+
+        let rmb = new HTTPMessageBusClient();
+        let msg = rmb.prepare("zos.statistics.get", [dstNodeId], 0, 2);
+        console.log(msg)
+        const messageIdentifier = await rmb.send(msg, "")
+        console.log(messageIdentifier)
+        
+        // set the retqueue to oringnal message
+        msg.ret = messageIdentifier["retqueue"];
+        await delay(7);
+
+        const result = await rmb.read(msg)
+        console.log(`the read response is: ${result}`)
+    }
+
+    deploy()
+}
+
+main()

--- a/scripts/softHttpClientTest.ts
+++ b/scripts/softHttpClientTest.ts
@@ -12,7 +12,7 @@ async function main() {
 
     async function deploy() {
 
-        let rmb = new HTTPMessageBusClient();
+        let rmb = new HTTPMessageBusClient("https://rmbproxy1.devnet.grid.tf");
         let msg = rmb.prepare("zos.statistics.get", [dstNodeId], 0, 2);
         console.log(msg)
         const messageIdentifier = await rmb.send(msg, "")

--- a/src/rmb/clientInterface.ts
+++ b/src/rmb/clientInterface.ts
@@ -1,0 +1,11 @@
+
+
+interface MessageBusClientInterface {
+    client: any;
+    prepare(command: string, destination:string, expiration: number, retry:number): object;
+    send(message:object,payload:object): void;
+    read(message:object): object;
+}
+
+
+export { MessageBusClientInterface }

--- a/src/rmb/httpClient.ts
+++ b/src/rmb/httpClient.ts
@@ -4,6 +4,10 @@ import { MessageBusClientInterface } from "./clientInterface"
 
 class HTTPMessageBusClient implements MessageBusClientInterface {
     client: any;
+    proxyURL: string;
+    constructor(proxyURL: string) {
+        this.proxyURL = proxyURL;
+    }
 
     prepare(command, destination, expiration, retry) {
         return {
@@ -33,7 +37,7 @@ class HTTPMessageBusClient implements MessageBusClientInterface {
         const body = JSON.stringify(message)
         const dst = message.dst[0]
 
-        await axios.post(`https://rmbproxy1.devnet.grid.tf/twin/${dst}`, body)
+        await axios.post(`${this.proxyURL}/twin/${dst}`, body)
             .then(res => {
                 console.log(`the send api response: ${res.status}`);
                 return res.json()
@@ -52,7 +56,7 @@ class HTTPMessageBusClient implements MessageBusClientInterface {
         }
 
 
-        axios.post(`https://rmbproxy1.devnet.grid.tf/twin/${dst}/${retqueue}`)
+        axios.post(`${this.proxyURL}/twin/${dst}/${retqueue}`)
             .then(res => {
                 console.log(`the read api response for retqueue ( ${retqueue} ) is : ${res.status}`);
                 return res.json()

--- a/src/rmb/httpClient.ts
+++ b/src/rmb/httpClient.ts
@@ -1,0 +1,67 @@
+const axios = require('axios')
+
+import { MessageBusClientInterface } from "./clientInterface"
+
+class HTTPMessageBusClient implements MessageBusClientInterface {
+    client: any;
+
+    prepare(command, destination, expiration, retry) {
+        return {
+            "ver": 1,
+            "uid": "",
+            "cmd": command,
+            "exp": expiration,
+            "dat": "",
+            "src": 0,
+            "dst": destination,
+            "ret": null,
+            "try": retry,
+            "shm": "",
+            "now": Math.floor(new Date().getTime() / 1000),
+            "err": "",
+        }
+    }
+
+    async send(message, payload) {
+        const buffer = new Buffer(payload);
+        message.dat = buffer.toString("base64");
+        
+        if (message.dst.length > 1) {
+            throw new Error('Http client does not support multi destinations');
+        }
+        
+        const body = JSON.stringify(message)
+        const dst = message.dst[0]
+
+        await axios.post(`https://rmbproxy1.devnet.grid.tf/twin/${dst}`, body)
+            .then(res => {
+                console.log(`the send api response: ${res.status}`);
+                return res.json()
+            })
+            .catch(error => {
+                // console.log(error);
+                throw new Error(error.response.data);
+            })
+    }
+
+    async read(message) {
+        const dst = message.dst[0]
+        const retqueue = message.ret
+        if (!retqueue) {
+            throw new Error('The Message retqueue is null');
+        }
+
+
+        axios.post(`https://rmbproxy1.devnet.grid.tf/twin/${dst}/${retqueue}`)
+            .then(res => {
+                console.log(`the read api response for retqueue ( ${retqueue} ) is : ${res.status}`);
+                return res.json()
+            })
+            .catch(error => {
+                throw new Error(error.response.data);
+            })
+    }
+}
+
+
+export { HTTPMessageBusClient }

--- a/src/rmb/index.ts
+++ b/src/rmb/index.ts
@@ -1,2 +1,3 @@
-export * from './client'
+export * from './redisClient'
+export * from './httpClient'
 export * from './server'

--- a/src/rmb/redisClient.ts
+++ b/src/rmb/redisClient.ts
@@ -1,7 +1,9 @@
 const redis = require("redis")
 const uuid4 = require("uuid4")
 
-class MessageBusClient {
+import { MessageBusClientInterface } from "./clientInterface"
+
+class RedisMessageBusClient implements MessageBusClientInterface {
     client: any;
     constructor(port = 6379) {
         const client = redis.createClient(port)
@@ -65,4 +67,4 @@ class MessageBusClient {
 }
 
 
-export { MessageBusClient }
+export { RedisMessageBusClient }


### PR DESCRIPTION
- implement RMB httpClient 
- Add test scripts

### example 
```js
async function main() {
    const dstNodeId = 38;

    async function deploy() {

        let rmb = new HTTPMessageBusClient("https://rmbproxy1.devnet.grid.tf");
        let msg = rmb.prepare("zos.statistics.get", [dstNodeId], 0, 2);
        console.log(msg)
        const messageIdentifier = await rmb.send(msg, "")
        console.log(messageIdentifier)
        
        // set the retqueue to oringnal message
        msg.ret = messageIdentifier["retqueue"];
        await delay(7);

        const result = await rmb.read(msg)
        console.log(`the read response is: ${result}`)
    }

    deploy()
}
```