### PR TITLE
Remove twin_id from grid client and get it with the public key of substrate account

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,5 @@
 {
     "url": "wss://tfchain.test.threefold.io/ws",
     "mnemonic": "",
-    "twin_id": 0,
     "rmb_proxy": "https://rmbproxy1.testnet.grid.tf"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "grid3_client",
     "author": "Ahmed Hanafy",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "homepage": "https://github.com/threefoldtech/grid3_client_ts/blob/development/README.md",
     "repository": {
         "type": "git",
@@ -18,7 +18,7 @@
         "private-ip": "^2.3.0",
         "reflect-metadata": "^0.1.13",
         "stellar-sdk": "^8.3.0",
-        "tfgrid-api-client": "^0.1.11",
+        "tfgrid-api-client": "^0.1.12",
         "ts-rmb-client-base": "^0.0.1",
         "ts-rmb-http-client": "^0.1.6",
         "ts-rmb-redis-client": "^0.0.3",

--- a/scripts/client_loader.ts
+++ b/scripts/client_loader.ts
@@ -8,14 +8,16 @@ import { MessageBusClient } from "ts-rmb-redis-client";
 
 const config = JSON.parse(fs.readFileSync(path.join(__dirname, "./testnet_config.json"), "utf-8"));
 
-function getClient(): GridClient {
+async function getClient(): Promise<GridClient> {
     let rmb: MessageBusClientInterface;
     if (config.proxy) {
-        rmb = new HTTPMessageBusClient(config.twin_id, config.proxy);
+        rmb = new HTTPMessageBusClient(0, config.proxy);
     } else {
         rmb = new MessageBusClient();
     }
-    return new GridClient(config.twin_id, config.url, config.mnemonic, rmb);
+    const gridClient = new GridClient(config.url, config.mnemonic, rmb);
+    await gridClient.connect();
+    return gridClient;
 }
 
 export { config, getClient };

--- a/scripts/fqdn_gateway.ts
+++ b/scripts/fqdn_gateway.ts
@@ -4,8 +4,6 @@ import { GatewayFQDNModel, GatewayFQDNDeleteModel } from "../src/modules/models"
 
 import { getClient } from "./client_loader";
 
-const grid3 = getClient();
-
 // read more about the gateway types in this doc: https://github.com/threefoldtech/zos/tree/main/docs/gateway
 
 const gw = new GatewayFQDNModel();
@@ -17,6 +15,7 @@ gw.backends = ["http://185.206.122.35:8000"];
 
 async function main() {
     // deploy
+    const grid3 = await getClient();
     const res = await grid3.gateway.deploy_fqdn(gw);
     console.log(JSON.stringify(res));
 

--- a/scripts/kubernetes.ts
+++ b/scripts/kubernetes.ts
@@ -3,8 +3,6 @@ import "reflect-metadata";
 import { NetworkModel, K8SModel, KubernetesNodeModel, K8SDeleteModel } from "../src/modules/models";
 import { getClient } from "./client_loader";
 
-const grid3 = getClient();
-
 // create network Object
 const n = new NetworkModel();
 n.name = "monNetwork";
@@ -45,6 +43,7 @@ k.ssh_key =
     "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDWlguBuvfQikkRJZXkLPei7Scvo/OULUEvjWVR4tCZ5V85P2F4SsSghxpRGixCNc7pNtgvdwJegK06Tn7SkV2jYJ9kBJh8PA06CPSz1mnpco4cgktiWx/R8xBvLGlyO0BwUuD3/WFjrc6fzH9E7Bpkel/xTnacx14w1bZAC1R35hz7BaHu1WrXsfxEd0VH7gpMPoQ4+l+H38ULPTiC+JcOKJOqVafgcc0sU7otXbgCa1Frr4QE5bwiMYhOlsRfRv/hf08jYsVo+RUO3wD12ylLWR7a7sJDkBBwgir8SwAvtRlT6k9ew9cDMQ7H8iWNCOg2xqoTLpVag6RN9kGzA5LGL+qHEcBr6gd2taFEy9+mt+TWuKp6reUeJfTu9RD1UgB0HpcdgTHtoUTISW7Mz4KNkouci2DJFngDWrLRxRoz81ZwfI2hjFY0PYDzF471K7Nwwt3qKYF1Js9a6VO38tMxSU4mTO83bt+dUFozgpw2Y0KKJGHDwU66i2MvTPg3EGs= ayoub@ayoub-Inspiron-3576";
 
 async function main() {
+    const grid3 = await getClient();
     // deploy k8s
     const res = await grid3.k8s.deploy(k);
     console.log(res);

--- a/scripts/multiple_vms.ts
+++ b/scripts/multiple_vms.ts
@@ -3,8 +3,6 @@ import "reflect-metadata";
 import { NetworkModel, MachineModel, MachinesModel, DiskModel, MachinesDeleteModel } from "../src/modules/models";
 import { getClient } from "./client_loader";
 
-const grid3 = getClient();
-
 // create network Object
 const n = new NetworkModel();
 n.name = "monNetwork";
@@ -39,7 +37,6 @@ disk2.name = "newDisk";
 disk2.size = 10;
 disk2.mountpoint = "/newDisk";
 
-
 // create another vm node Object
 const vm2 = new MachineModel();
 vm2.name = "testvm";
@@ -66,6 +63,8 @@ vms.metadata = "{'testVMs': true}";
 vms.description = "test deploying VMs via ts grid3 client";
 
 async function main() {
+    const grid3 = await getClient();
+
     // deploy vms
     const res = await grid3.machines.deploy(vms);
     console.log(JSON.stringify(res));

--- a/scripts/name_gateway.ts
+++ b/scripts/name_gateway.ts
@@ -4,8 +4,6 @@ import { GatewayNameModel, GatewayNameDeleteModel } from "../src/modules/models"
 
 import { getClient } from "./client_loader";
 
-const grid3 = getClient();
-
 // read more about the gateway types in this doc: https://github.com/threefoldtech/zos/tree/main/docs/gateway
 
 const gw = new GatewayNameModel();
@@ -15,6 +13,8 @@ gw.tls_passthrough = false;
 gw.backends = ["http://185.206.122.35:8000"];
 
 async function main() {
+    const grid3 = await getClient();
+
     // deploy
     const res = await grid3.gateway.deploy_name(gw);
     console.log(JSON.stringify(res));

--- a/scripts/single_vm.ts
+++ b/scripts/single_vm.ts
@@ -3,8 +3,6 @@ import "reflect-metadata";
 import { NetworkModel, MachineModel, MachinesModel, DiskModel, MachinesDeleteModel } from "../src/modules/models";
 import { getClient } from "./client_loader";
 
-const grid3 = getClient();
-
 // create network Object
 const n = new NetworkModel();
 n.name = "wedtest";
@@ -42,6 +40,8 @@ vms.metadata = "{'testVMs': true}";
 vms.description = "test deploying VMs via ts grid3 client";
 
 async function main() {
+    const grid3 = await getClient();
+
     // deploy vms
     const res = await grid3.machines.deploy(vms);
     console.log(JSON.stringify(res));

--- a/scripts/testnet_config.json
+++ b/scripts/testnet_config.json
@@ -1,5 +1,4 @@
 {
-    "twin_id": 0,
     "mnemonic": "",
     "url": "wss://tfchain.test.threefold.io/ws",
     "proxy": "https://rmbproxy1.testnet.grid.tf"

--- a/scripts/vm_with_qsfs.ts
+++ b/scripts/vm_with_qsfs.ts
@@ -1,11 +1,10 @@
 import "reflect-metadata";
-import { getClient } from "./clientLoader";
+import { getClient } from "./client_loader";
 
-const grid3 = getClient();
 const qsfs_name = "wed2710q1";
 const machines_name = "wed2710t1";
 
-async function deploy() {
+async function deploy(grid3) {
     // deploy qsfs backend zdbs first
     const qsfs_res = await grid3.qsfs_zdbs.deploy({
         name: qsfs_name,
@@ -14,7 +13,7 @@ async function deploy() {
         password: "mypassword",
         disk_size: 10,
         description: "my qsfs test",
-        metadata: ""
+        metadata: "",
     });
     console.log(">>>>>>>>>>>>>>>QSFS backend has been created<<<<<<<<<<<<<<<");
     console.log(JSON.stringify(qsfs_res));
@@ -26,54 +25,57 @@ async function deploy() {
             name: "wed2710n1",
             ip_range: "10.201.0.0/16",
         },
-        machines: [{
-            name: "wed2710v1",
-            node_id: 7,
-            disks: [{
-                name: "wed2710d1",
-                size: 10,
-                mountpoint: "/mydisk",
-            }],
-            qsfs_disks: [{
-                qsfs_zdbs_name: qsfs_name,
-                name: "wed2710d2",
-                minimal_shards: 2,
-                expected_shards: 4,
-                encryption_key: "hamada",
-                prefix: "hamada",
-                cache: 1,
-                mountpoint: "/myqsfsdisk"
-            }],
-            public_ip: false,
-            planetary: true,
-            cpu: 1,
-            memory: 1024 * 2,
-            rootfs_size: 1,
-            flist: "https://hub.grid.tf/tf-official-apps/base:latest.flist",
-            entrypoint: "/sbin/zinit init",
-            env: {
-                SSH_KEY:
-                    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDWlguBuvfQikkRJZXkLPei7Scvo/OULUEvjWVR4tCZ5V85P2F4SsSghxpRGixCNc7pNtgvdwJegK06Tn7SkV2jYJ9kBJh8PA06CPSz1mnpco4cgktiWx/R8xBvLGlyO0BwUuD3/WFjrc6fzH9E7Bpkel/xTnacx14w1bZAC1R35hz7BaHu1WrXsfxEd0VH7gpMPoQ4+l+H38ULPTiC+JcOKJOqVafgcc0sU7otXbgCa1Frr4QE5bwiMYhOlsRfRv/hf08jYsVo+RUO3wD12ylLWR7a7sJDkBBwgir8SwAvtRlT6k9ew9cDMQ7H8iWNCOg2xqoTLpVag6RN9kGzA5LGL+qHEcBr6gd2taFEy9+mt+TWuKp6reUeJfTu9RD1UgB0HpcdgTHtoUTISW7Mz4KNkouci2DJFngDWrLRxRoz81ZwfI2hjFY0PYDzF471K7Nwwt3qKYF1Js9a6VO38tMxSU4mTO83bt+dUFozgpw2Y0KKJGHDwU66i2MvTPg3EGs= ayoub@ayoub-Inspiron-3576",
-            }
-        }],
+        machines: [
+            {
+                name: "wed2710v1",
+                node_id: 7,
+                disks: [
+                    {
+                        name: "wed2710d1",
+                        size: 10,
+                        mountpoint: "/mydisk",
+                    },
+                ],
+                qsfs_disks: [
+                    {
+                        qsfs_zdbs_name: qsfs_name,
+                        name: "wed2710d2",
+                        minimal_shards: 2,
+                        expected_shards: 4,
+                        encryption_key: "hamada",
+                        prefix: "hamada",
+                        cache: 1,
+                        mountpoint: "/myqsfsdisk",
+                    },
+                ],
+                public_ip: false,
+                planetary: true,
+                cpu: 1,
+                memory: 1024 * 2,
+                rootfs_size: 1,
+                flist: "https://hub.grid.tf/tf-official-apps/base:latest.flist",
+                entrypoint: "/sbin/zinit init",
+                env: {
+                    SSH_KEY:
+                        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDWlguBuvfQikkRJZXkLPei7Scvo/OULUEvjWVR4tCZ5V85P2F4SsSghxpRGixCNc7pNtgvdwJegK06Tn7SkV2jYJ9kBJh8PA06CPSz1mnpco4cgktiWx/R8xBvLGlyO0BwUuD3/WFjrc6fzH9E7Bpkel/xTnacx14w1bZAC1R35hz7BaHu1WrXsfxEd0VH7gpMPoQ4+l+H38ULPTiC+JcOKJOqVafgcc0sU7otXbgCa1Frr4QE5bwiMYhOlsRfRv/hf08jYsVo+RUO3wD12ylLWR7a7sJDkBBwgir8SwAvtRlT6k9ew9cDMQ7H8iWNCOg2xqoTLpVag6RN9kGzA5LGL+qHEcBr6gd2taFEy9+mt+TWuKp6reUeJfTu9RD1UgB0HpcdgTHtoUTISW7Mz4KNkouci2DJFngDWrLRxRoz81ZwfI2hjFY0PYDzF471K7Nwwt3qKYF1Js9a6VO38tMxSU4mTO83bt+dUFozgpw2Y0KKJGHDwU66i2MvTPg3EGs= ayoub@ayoub-Inspiron-3576",
+                },
+            },
+        ],
         metadata: "{'testVMs': true}",
         description: "test deploying VMs via ts grid3 client",
-
-
     });
     console.log(">>>>>>>>>>>>>>>VM has been created<<<<<<<<<<<<<<<");
     console.log(JSON.stringify(res));
-
 }
 
-async function get() {
+async function get(grid3) {
     // get the deployment
     const l = await grid3.machines.getObj(machines_name);
     console.log(">>>>>>>>>>>>>>>Deployment result<<<<<<<<<<<<<<<");
     console.log(JSON.stringify(l));
 }
 
-async function cancel() {
+async function cancel(grid3) {
     // delete
     const d = await grid3.machines.delete({ name: machines_name });
     console.log(d);
@@ -82,11 +84,12 @@ async function cancel() {
 }
 
 async function main() {
-    await deploy();
+    const grid3 = await getClient();
+    await deploy(grid3);
 
-    await get();
+    await get(grid3);
 
-    // await cancel();
+    // await cancel(grid3);
 }
 
 main();

--- a/scripts/zdb.ts
+++ b/scripts/zdb.ts
@@ -1,11 +1,9 @@
 import "reflect-metadata";
 
-import { ZDBModel, ZDBSModel, ZDBDeleteModel } from "../dist/node/modules/models";
-import { ZdbModes } from "../dist/node/zos/zdb";
+import { ZDBModel, ZDBSModel, ZDBDeleteModel } from "../src/modules/models";
+import { ZdbModes } from "../src/zos/zdb";
 
-import { getClient } from "./clientLoader";
-
-const grid3 = getClient();
+import { getClient } from "./client_loader";
 
 // create zdb object
 const zdb = new ZDBModel();
@@ -23,6 +21,8 @@ zdbs.zdbs = [zdb];
 zdbs.metadata = '{"test": "test"}';
 
 async function main() {
+    const grid3 = await getClient();
+
     const res = await grid3.zdbs.deploy(zdbs);
     console.log(JSON.stringify(res));
 

--- a/src/clients/rmb/client.ts
+++ b/src/clients/rmb/client.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { MessageBusClientInterface } from "ts-rmb-client-base";
 import { MessageBusClient } from "ts-rmb-redis-client";
 import { HTTPMessageBusClient } from "ts-rmb-http-client";
@@ -5,7 +6,7 @@ import { argv, env } from "process";
 
 import { loadFromFile } from "../../helpers/jsonfs";
 
-const config = loadFromFile("../../../config.json");
+const config = loadFromFile(path.join(__dirname, "../../../config.json"));
 
 function getRmbProxy(): string {
     let rmb_proxy = "";
@@ -36,7 +37,7 @@ function getRmbProxy(): string {
 function getRMBClient(): MessageBusClientInterface {
     const rmb_proxy = getRmbProxy();
     if (rmb_proxy) {
-        return new HTTPMessageBusClient(config.twin_id, rmb_proxy);
+        return new HTTPMessageBusClient(0, rmb_proxy);
     } else {
         return new MessageBusClient();
     }

--- a/src/clients/tf-grid/client.ts
+++ b/src/clients/tf-grid/client.ts
@@ -63,7 +63,6 @@ class TFClient {
             console.log(`Executing method: ${method.name} with args: ${args}`);
             result = await method.apply(context, args);
         } catch (e) {
-            console.log(e);
             throw Error(e);
         } finally {
             this.disconnect();

--- a/src/clients/tf-grid/contracts.ts
+++ b/src/clients/tf-grid/contracts.ts
@@ -1,3 +1,8 @@
+enum ContractState {
+    Created = "Created",
+    Deleted = "Deleted",
+    OutOfFunds = "OutOfFunds",
+}
 class Contracts {
     tfclient;
 
@@ -44,8 +49,17 @@ class Contracts {
         return this.tfclient.client.getContractByID(id);
     }
 
+    async getContractIdByNodeIdAndHash(nodeId: number, hash: string) {
+        return this.tfclient.client.contractIDByNodeIDAndHash(nodeId, hash);
+    }
+
+    async getNodeContracts(nodeId: number, state: ContractState) {
+        return this.tfclient.client.nodeContracts(nodeId, state);
+    }
+
     async getNameContract(name: string) {
         return this.tfclient.client.contractIDByNameRegistration(name);
     }
 }
-export { Contracts };
+
+export { Contracts, ContractState };

--- a/src/clients/tf-grid/twins.ts
+++ b/src/clients/tf-grid/twins.ts
@@ -14,12 +14,12 @@ class Twins {
     }
 
     async getMyTwinId(): Promise<number> {
-        const pubKey = this.tfclient.client.key.address;
-        return await this.getTwinIdByAccountId(pubKey);
+        const pubKey = this.tfclient.client.address;
+        return this.getTwinIdByAccountId(pubKey);
     }
 
     async getTwinIdByAccountId(publicKey: string): Promise<number> {
-        return await this.tfclient.client.getTwinIdByAccountId(publicKey);
+        return this.tfclient.client.getTwinIdByAccountId(publicKey);
     }
 
     async list() {

--- a/src/clients/tf-grid/twins.ts
+++ b/src/clients/tf-grid/twins.ts
@@ -13,6 +13,15 @@ class Twins {
         return this.tfclient.client.getTwinByID(id);
     }
 
+    async getMyTwinId(): Promise<number> {
+        const pubKey = this.tfclient.client.key.address;
+        return await this.getTwinIdByAccountId(pubKey);
+    }
+
+    async getTwinIdByAccountId(publicKey: string): Promise<number> {
+        return await this.tfclient.client.getTwinIdByAccountId(publicKey);
+    }
+
     async list() {
         return this.tfclient.client.listTwins();
     }

--- a/src/modules/contracts.ts
+++ b/src/modules/contracts.ts
@@ -7,6 +7,9 @@ import {
     ContractGetModel,
     NodeContractUpdateModel,
     ContractCancelModel,
+    ContractGetByNodeIdAndHashModel,
+    NodeContractsGetModel,
+    NameContractGetModel,
 } from "./models";
 import { expose } from "../helpers/expose";
 
@@ -42,6 +45,27 @@ class Contracts {
     async get(options: ContractGetModel) {
         return await this.client.execute(this.context, this.client.contracts.get, [options.id]);
     }
+    @expose
+    async get_contract_id_by_node_id_and_hash(options: ContractGetByNodeIdAndHashModel) {
+        return await this.client.execute(this.context, this.client.contracts.getContractIdByNodeIdAndHash, [
+            options.node_id,
+            options.hash,
+        ]);
+    }
+
+    @expose
+    async get_node_contracts(options: NodeContractsGetModel) {
+        return await this.client.execute(this.context, this.client.contracts.getNodeContracts, [
+            options.node_id,
+            options.state,
+        ]);
+    }
+
+    @expose
+    async get_name_contract(options: NameContractGetModel) {
+        return await this.client.execute(this.context, this.client.contracts.getNameContract, [options.name]);
+    }
+
     @expose
     async update_node(options: NodeContractUpdateModel) {
         return await this.client.execute(this.context, this.client.contracts.updateNode, [

--- a/src/modules/models.ts
+++ b/src/modules/models.ts
@@ -1,3 +1,4 @@
+import { ContractState } from "../clients/tf-grid/contracts";
 import { Deployment } from "../zos/deployment";
 import { ZdbModes } from "../zos/zdb";
 
@@ -181,6 +182,20 @@ class ContractGetModel {
     id: number;
 }
 
+class ContractGetByNodeIdAndHashModel {
+    node_id: number;
+    hash: string;
+}
+
+class NodeContractsGetModel {
+    node_id: number;
+    state: ContractState;
+}
+
+class NameContractGetModel {
+    name: string;
+}
+
 class NodeContractUpdateModel {
     id: number;
     hash: string;
@@ -265,6 +280,9 @@ export {
     NodeContractCreateModel,
     NameContractCreateModel,
     ContractGetModel,
+    ContractGetByNodeIdAndHashModel,
+    NodeContractsGetModel,
+    NameContractGetModel,
     NodeContractUpdateModel,
     ContractCancelModel,
     TwinCreateModel,

--- a/src/modules/models.ts
+++ b/src/modules/models.ts
@@ -199,6 +199,10 @@ class TwinGetModel {
     id: number;
 }
 
+class TwinGetByAccountIdModel {
+    public_key: string;
+}
+
 class TwinDeleteModel {
     id: number;
 }
@@ -265,6 +269,7 @@ export {
     ContractCancelModel,
     TwinCreateModel,
     TwinGetModel,
+    TwinGetByAccountIdModel,
     TwinDeleteModel,
     WalletImportModel,
     WalletBalanceByNameModel,

--- a/src/modules/twins.ts
+++ b/src/modules/twins.ts
@@ -1,7 +1,7 @@
 import { MessageBusClientInterface } from "ts-rmb-client-base";
 
 import { TFClient } from "../clients/tf-grid/client";
-import { TwinCreateModel, TwinGetModel, TwinDeleteModel } from "./models";
+import { TwinCreateModel, TwinGetModel, TwinGetByAccountIdModel, TwinDeleteModel } from "./models";
 import { expose } from "../helpers/expose";
 
 class Twins {
@@ -26,6 +26,17 @@ class Twins {
     async get(options: TwinGetModel) {
         return await this.client.execute(this.context, this.client.twins.get, [options.id]);
     }
+
+    @expose
+    async get_my_twin_id() {
+        return await this.client.execute(this.context, this.client.twins.getMyTwinId, []);
+    }
+
+    @expose
+    async get_twin_id_by_account_id(options: TwinGetByAccountIdModel) {
+        return await this.client.execute(this.context, this.client.twins.getTwinIdByAccountId, [options.public_key]);
+    }
+
     @expose
     async list() {
         return await this.client.execute(this.context, this.client.twins.list, []);

--- a/src/modules/zdb.ts
+++ b/src/modules/zdb.ts
@@ -130,4 +130,4 @@ class ZdbsModule extends BaseModule {
     }
 }
 
-export { ZdbsModule as zdb };
+export { ZdbsModule as zdbs };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1159,9 +1159,9 @@ doctrine@^3.0.0:
     esutils "^2.0.2"
 
 electron-to-chromium@^1.3.878:
-  version "1.3.885"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.885.tgz#c8cec32fbc61364127849ae00f2395a1bae7c454"
-  integrity sha512-JXKFJcVWrdHa09n4CNZYfYaK6EW5aAew7/wr3L1OnsD1L+JHL+RCtd7QgIsxUbFPeTwPlvnpqNNTOLkoefmtXg==
+  version "1.3.886"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.886.tgz#ac039c4001b665b1dd0f0ed9c2e4da90ff3c9267"
+  integrity sha512-+vYdeBosI63VkCtNWnEVFjgNd/IZwvnsWkKyPtWAvrhA+XfByKoBJcbsMgudVU/bUcGAF9Xp3aXn96voWlc3oQ==
 
 elliptic@^6.5.4:
   version "6.5.4"
@@ -3005,10 +3005,10 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-tfgrid-api-client@^0.1.11:
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/tfgrid-api-client/-/tfgrid-api-client-0.1.11.tgz#0e73d6ce5ce1c740d6c47e1b4997811209ce356a"
-  integrity sha512-aCxA3Pokn1hJ94HewtCcUTfqPYWVhi0NW0ukHIGxlUyKmjva0BkXmz9tvw6WlYNMOVcFmnxvuHOY/DJk5+FfMw==
+tfgrid-api-client@^0.1.12:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/tfgrid-api-client/-/tfgrid-api-client-0.1.12.tgz#cc31d817ad8c3a015a659d3213f91db65de9b34d"
+  integrity sha512-gbif/Mv58B6RRSFWiiPgsYovXyrIZA8KOX0Z2K74OeYnkj30H+zkCRUXKO4tE6W4EYcGFHtHnlfnDyeHdKym3w==
   dependencies:
     "@encointer/util" "^0.3.2"
     "@encointer/worker-api" "^0.3.2"
@@ -3223,9 +3223,9 @@ validate-npm-package-license@^3.0.1:
     spdx-expression-parse "^3.0.0"
 
 validator@^13.5.2:
-  version "13.6.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-13.6.0.tgz#1e71899c14cdc7b2068463cb24c1cc16f6ec7059"
-  integrity sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
+  integrity sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==
 
 watchpack@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
- Add method to get twin id by account id
- Remove twin_id from grid client and get it with the public key of substrate account
- Update scripts and twin server to not require twin id
- Add methods for getting my twin id and getting twin by account id in twin module
- Add some methods for query contracts on contracts modules

### Related issues
- #26 