### PR TITLE
Expose capacity planner on twin server

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,5 +27,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Install
       run: yarn
-    - name: Run Lint
+    - name: src lint
       run: yarn eslint -c .eslintrc.json src/ 
+    - name: scripts lint
+      run: yarn eslint -c .eslintrc.json scripts/ 

--- a/docs/module.md
+++ b/docs/module.md
@@ -655,7 +655,7 @@ single master and multiple workers.
 
 - **Check Farm Has Free Public IPs**
 
-    cmd: `twinserver.capacity.CheckFarmHasFreePublicIps`
+    cmd: `twinserver.capacity.checkFarmHasFreePublicIps`
 
     payload: `'{"farmId": 1}'`
 

--- a/docs/module.md
+++ b/docs/module.md
@@ -14,77 +14,77 @@ Module should be:
 
 - **Create**
 
-   cmd: `twinserver.twins.create`
+    cmd: `twinserver.twins.create`
 
-   payload: `'{"ip": "<yggdrasil ip>"}'`
+    payload: `'{"ip": "<yggdrasil ip>"}'`
 
 - **Get**
 
-   cmd: `twinserver.twins.get`
+    cmd: `twinserver.twins.get`
 
-   payload: `'{"id": <twin id>}'`
+    payload: `'{"id": <twin id>}'`
 
 - **Get my twin id**
 
-   cmd: `twinserver.twins.get_my_twin_id`
+    cmd: `twinserver.twins.get_my_twin_id`
 
-   payload: `""`
+    payload: `""`
 
 - **Get twin id by account id**
 
-   cmd: `twinserver.twins.get_twin_id_by_account_id`
+    cmd: `twinserver.twins.get_twin_id_by_account_id`
 
-   payload: `'{"public_key": <substrate account id>}'`
+    payload: `'{"public_key": <substrate account id>}'`
 
 - **List**
 
-   cmd: `twinserver.twins.list`
+    cmd: `twinserver.twins.list`
 
-   payload: `""`
+    payload: `""`
 
 - **Delete**
 
-   cmd: `twinserver.twins.delete`
+    cmd: `twinserver.twins.delete`
 
-   payload: `'{"id": <twin id>}'`
+    payload: `'{"id": <twin id>}'`
 
 ### Contracts
 
 - **Create Node**
 
-   cmd: `twinserver.contracts.create_node`
+    cmd: `twinserver.contracts.create_node`
 
-   payload: `'{"node_id": "<zos node id>", "hash": "<deployment challenge hash>", "data": "<deployment data>", "public_ip": <number of public IPs>}'`
+    payload: `'{"node_id": "<zos node id>", "hash": "<deployment challenge hash>", "data": "<deployment data>", "public_ip": <number of public IPs>}'`
 
 - **Create Name**
 
-   cmd: `twinserver.contracts.create_name`
+    cmd: `twinserver.contracts.create_name`
 
-   payload: `'{"name": "<contract name>"}'`
+    payload: `'{"name": "<contract name>"}'`
 
 - **Get**
 
-   cmd: `twinserver.contracts.get`
+    cmd: `twinserver.contracts.get`
 
-   payload: `'{"id": <contract id>}'`
+    payload: `'{"id": <contract id>}'`
 
 - **Get contract id by node id and hash**
 
-   cmd: `twinserver.contracts.get_contract_id_by_node_id_and_hash`
+    cmd: `twinserver.contracts.get_contract_id_by_node_id_and_hash`
 
-   payload: `'{"node_id": 1, "hash": <deployment challenge hash>}'`
+    payload: `'{"node_id": 1, "hash": <deployment challenge hash>}'`
 
 - **Get node contracts**
 
-   cmd: `twinserver.contracts.get_node_contracts`
+    cmd: `twinserver.contracts.get_node_contracts`
 
-   payload: `'{"node_id": 1, "state": <contracts state should be "Created", "Deleted", or "OutOfFunds">}'`
+    payload: `'{"node_id": 1, "state": <contracts state should be "Created", "Deleted", or "OutOfFunds">}'`
 
 - **Get name contract**
 
-   cmd: `twinserver.contracts.get_name_contract`
+    cmd: `twinserver.contracts.get_name_contract`
 
-   payload: `'{"name": <contract name>}'`
+    payload: `'{"name": <contract name>}'`
 
 - **Update Node**
 
@@ -94,19 +94,19 @@ Module should be:
 
 - **Cancel**
 
-   cmd: `twinserver.contracts.cancel`
+    cmd: `twinserver.contracts.cancel`
 
-   payload: `'{"id": <contract id>}'`
+    payload: `'{"id": <contract id>}'`
 
 ### ZOS
 
 - **Deploy**
 
-   cmd: `twinserver.zos.deploy`
+    cmd: `twinserver.zos.deploy`
 
-   payload: the same as zos deployment without signing with additional parameter `'{"node_id": <zos node id> }'`
+    payload: the same as zos deployment without signing with additional parameter `'{"node_id": <zos node id> }'`
 
-**Note:** `node_id` will be optional when the grid3_proxy_server is ready to be used.
+    > **Note:** `node_id` will be optional when the grid3_proxy_server is ready to be used.
 
 ### Generic Machines
 
@@ -116,33 +116,88 @@ Module should be:
 
     payload:
 
-```json
-{
-        "name": "wed1310t1",
-        "network": {
-            "ip_range": "10.203.0.0/16",
-            "name": "wed159n3"
-        },
-        "machines": [{
-            "name": "wed1310t2",
-            "node_id": 3,
+    ```json
+    {
+            "name": "wed1310t1",
+            "network": {
+                "ip_range": "10.203.0.0/16",
+                "name": "wed159n3"
+            },
+            "machines": [{
+                "name": "wed1310t2",
+                "node_id": 3,
+                "disks": [
+                    {
+                        "name": "wed1310d2",
+                        "size": 10,
+                        "mountpoint": "/hamada"
+                    }
+                ],
+                "qsfs_disks":[
+                    {
+                        "qsfs_zdbs_name": "hamada",
+                        "name": "mon2410t2",
+                        "prefix": "hamada",
+                        "cache": 1, // in GB
+                        "minimal_shards": 2, 
+                        "expected_shards": 4,
+                        "encryption_key": "hamada",
+                        "mountpoint": "/ahmed",
+                    }
+                ],
+                "public_ip": false,
+                "planetary": true,
+                "cpu": 1,
+                "memory": 1024,
+                "rootfs_size": 1,
+                "flist": "https://hub.grid.tf/tf-official-apps/base:latest.flist",
+                "entrypoint": "/sbin/zinit init",
+                "env": {
+                    "SSH_KEY": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDmm8OzLt+lTdGaMUwMFcw0P+vr+a/h/UsR//EzzeQsgNtC0bdls4MawVEhb3hNcycEQNd2P/+tXdLC4qcaJ6iABYip4xqqAeY098owGDYhUKYwmnMyo+NwSgpjZs8taOhMxh5XHRI+Ifr4l/GmzbqExS0KVD21PI+4sdiLspbcnVBlg9Eg9enM///zx6rSkulrca/+MnSYHboC5+y4XLYboArD/gpWy3zwIUyxX/1MjJwPeSnd5LFBIWvPGrm3cl+dAtADwTZRkt5Yuet8y5HI73Q5/NSlCdYXMtlsKBLpJu3Ar8nz1QfSQL7dB8pa7/sf/s8wO17rXqWQgZG6JzvZ root@ahmed-Inspiron-3576"
+                }
+            }],
+            "metadata": "",
+            "description": ""
+        };
+
+    ```
+
+    > **Note:** disk size and rootfs_size in GB, memory in MB, disk name should be different than the machine name
+
+- **List**
+
+    cmd: `twinserver.machines.list`
+
+    payload: `""`
+
+- **Get**
+
+    cmd: `twinserver.machines.get`
+
+    payload: `{"name": "<deployment name>"}`
+
+- **Delete**
+
+    cmd: `twinserver.machines.delete`
+
+    payload: `{"name": "<deployment name>"}`
+
+- **Add machine**
+
+    cmd: `twinserver.machines.add_machine`
+
+    payload:
+
+    ```json
+    {
+            "deployment_name": "wed1310t1",
+            "name": "wed1310m4",
+            "node_id": 2,
             "disks": [
                 {
-                    "name": "wed1310d2",
+                    "name": "wed1310d4",
                     "size": 10,
                     "mountpoint": "/hamada"
-                }
-            ],
-            "qsfs_disks":[
-                {
-                    "qsfs_zdbs_name": "hamada",
-                    "name": "mon2410t2",
-                    "prefix": "hamada",
-                    "cache": 1, // in GB
-                    "minimal_shards": 2, 
-                    "expected_shards": 4,
-                    "encryption_key": "hamada",
-                    "mountpoint": "/ahmed",
                 }
             ],
             "public_ip": false,
@@ -155,76 +210,21 @@ Module should be:
             "env": {
                 "SSH_KEY": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDmm8OzLt+lTdGaMUwMFcw0P+vr+a/h/UsR//EzzeQsgNtC0bdls4MawVEhb3hNcycEQNd2P/+tXdLC4qcaJ6iABYip4xqqAeY098owGDYhUKYwmnMyo+NwSgpjZs8taOhMxh5XHRI+Ifr4l/GmzbqExS0KVD21PI+4sdiLspbcnVBlg9Eg9enM///zx6rSkulrca/+MnSYHboC5+y4XLYboArD/gpWy3zwIUyxX/1MjJwPeSnd5LFBIWvPGrm3cl+dAtADwTZRkt5Yuet8y5HI73Q5/NSlCdYXMtlsKBLpJu3Ar8nz1QfSQL7dB8pa7/sf/s8wO17rXqWQgZG6JzvZ root@ahmed-Inspiron-3576"
             }
-        }],
-        "metadata": "",
-        "description": ""
-    };
-
-```
-
-**Note:** disk size and rootfs_size in GB, memory in MB, disk name should be different than the machine name
-
-- **List**
-
-cmd: `twinserver.machines.list`
-
-payload: `""`
-
-- **Get**
-
-cmd: `twinserver.machines.get`
-
-payload: `{"name": "<deployment name>"}`
-
-- **Delete**
-
-cmd: `twinserver.machines.delete`
-
-payload: `{"name": "<deployment name>"}`
-
-- **Add machine**
-
-cmd: `twinserver.machines.add_machine`
-
-payload:
-
-```json
-{
-        "deployment_name": "wed1310t1",
-        "name": "wed1310m4",
-        "node_id": 2,
-        "disks": [
-            {
-                "name": "wed1310d4",
-                "size": 10,
-                "mountpoint": "/hamada"
-            }
-        ],
-        "public_ip": false,
-        "planetary": true,
-        "cpu": 1,
-        "memory": 1024,
-        "rootfs_size": 1,
-        "flist": "https://hub.grid.tf/tf-official-apps/base:latest.flist",
-        "entrypoint": "/sbin/zinit init",
-        "env": {
-            "SSH_KEY": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDmm8OzLt+lTdGaMUwMFcw0P+vr+a/h/UsR//EzzeQsgNtC0bdls4MawVEhb3hNcycEQNd2P/+tXdLC4qcaJ6iABYip4xqqAeY098owGDYhUKYwmnMyo+NwSgpjZs8taOhMxh5XHRI+Ifr4l/GmzbqExS0KVD21PI+4sdiLspbcnVBlg9Eg9enM///zx6rSkulrca/+MnSYHboC5+y4XLYboArD/gpWy3zwIUyxX/1MjJwPeSnd5LFBIWvPGrm3cl+dAtADwTZRkt5Yuet8y5HI73Q5/NSlCdYXMtlsKBLpJu3Ar8nz1QfSQL7dB8pa7/sf/s8wO17rXqWQgZG6JzvZ root@ahmed-Inspiron-3576"
         }
-    }
-```
+    ```
 
 - **Delete machine**
 
-cmd: `twinserver.machines.delete_machine`
+    cmd: `twinserver.machines.delete_machine`
 
-payload:
+    payload:
 
-```json
-{
-        "deployment_name": "wed1310t1",
-        "name": "wed1310m2",
-    }
-```
+    ```json
+    {
+            "deployment_name": "wed1310t1",
+            "name": "wed1310m2",
+        }
+    ```
 
 ### Kubernetes
 
@@ -236,98 +236,98 @@ single master and multiple workers.
 
     payload:
 
-```json
-{
-        "name": "mon69t5",
-        "secret": "hamadaellol",
-        "network": {
-                "name": "hamadanet",
-                "ip_range": "10.201.0.0/16"
-        },
-        "masters": [
-            {
-                "name": "master1",
-                "node_id": 3,
-                "cpu": 1,
-                "memory": 1024,
-                "rootfs_size": 1,
-                "disk_size": 15,
-                "public_ip": true,
-                "planetary": true
-            }
-        ],
-        "workers": [
-            {
-                "name":"worker1" ,
-                "node_id": 2,
-                "cpu": 1,
-                "memory": 1024,
-                "rootfs_size": 1,
-                "disk_size": 15,
-                "public_ip": false,
-                "planetary": true
+    ```json
+    {
+            "name": "mon69t5",
+            "secret": "hamadaellol",
+            "network": {
+                    "name": "hamadanet",
+                    "ip_range": "10.201.0.0/16"
+            },
+            "masters": [
+                {
+                    "name": "master1",
+                    "node_id": 3,
+                    "cpu": 1,
+                    "memory": 1024,
+                    "rootfs_size": 1,
+                    "disk_size": 15,
+                    "public_ip": true,
+                    "planetary": true
+                }
+            ],
+            "workers": [
+                {
+                    "name":"worker1" ,
+                    "node_id": 2,
+                    "cpu": 1,
+                    "memory": 1024,
+                    "rootfs_size": 1,
+                    "disk_size": 15,
+                    "public_ip": false,
+                    "planetary": true
 
-            }
-        ],
-        "metadata": "",
-        "description": "",
-        "ssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDmm8OzLt+lTdGaMUwMFcw0P+vr+a/h/UsR//EzzeQsgNtC0bdls4MawVEhb3hNcycEQNd2P/+tXdLC4qcaJ6iABYip4xqqAeY098owGDYhUKYwmnMyo+NwSgpjZs8taOhMxh5XHRI+Ifr4l/GmzbqExS0KVD21PI+4sdiLspbcnVBlg9Eg9enM///zx6rSkulrca/+MnSYHboC5+y4XLYboArD/gpWy3zwIUyxX/1MjJwPeSnd5LFBIWvPGrm3cl+dAtADwTZRkt5Yuet8y5HI73Q5/NSlCdYXMtlsKBLpJu3Ar8nz1QfSQL7dB8pa7/sf/s8wO17rXqWQgZG6JzvZ root@ahmed-Inspiron-3576"
-    }
-```
+                }
+            ],
+            "metadata": "",
+            "description": "",
+            "ssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDmm8OzLt+lTdGaMUwMFcw0P+vr+a/h/UsR//EzzeQsgNtC0bdls4MawVEhb3hNcycEQNd2P/+tXdLC4qcaJ6iABYip4xqqAeY098owGDYhUKYwmnMyo+NwSgpjZs8taOhMxh5XHRI+Ifr4l/GmzbqExS0KVD21PI+4sdiLspbcnVBlg9Eg9enM///zx6rSkulrca/+MnSYHboC5+y4XLYboArD/gpWy3zwIUyxX/1MjJwPeSnd5LFBIWvPGrm3cl+dAtADwTZRkt5Yuet8y5HI73Q5/NSlCdYXMtlsKBLpJu3Ar8nz1QfSQL7dB8pa7/sf/s8wO17rXqWQgZG6JzvZ root@ahmed-Inspiron-3576"
+        }
+    ```
 
-**Note:** disk size and rootfs_size in GB, memory in MB, masters and workers names should be different
+    > **Note:** disk size and rootfs_size in GB, memory in MB, masters and workers names should be different
 
 - **List**
 
-cmd: `twinserver.k8s.list`
+    cmd: `twinserver.k8s.list`
 
-payload: `""`
+    payload: `""`
 
 - **Get**
 
-cmd: `twinserver.k8s.get`
+    cmd: `twinserver.k8s.get`
 
-payload: `{"name": "<deployment name>"}`
+    payload: `{"name": "<deployment name>"}`
 
 - **Delete**
 
-cmd: `twinserver.k8s.delete`
+    cmd: `twinserver.k8s.delete`
 
-payload: `{"name": "<deployment name>"}`
+    payload: `{"name": "<deployment name>"}`
 
 - **Add worker**
 
-cmd: `twinserver.k8s.add_worker`
+    cmd: `twinserver.k8s.add_worker`
 
-payload:
+    payload:
 
-```json
-{
-        "deployment_name": "sun199t2",
-        "name": "sun199t1worker5",
-        "node_id": 5,
-        "cpu": 2,
-        "memory": 1024,
-        "rootfs_size": 1,
-        "disk_size": 15,
-        "public_ip": false,
-        "planetary": true
-        
-    }
-```
+    ```json
+    {
+            "deployment_name": "sun199t2",
+            "name": "sun199t1worker5",
+            "node_id": 5,
+            "cpu": 2,
+            "memory": 1024,
+            "rootfs_size": 1,
+            "disk_size": 15,
+            "public_ip": false,
+            "planetary": true
+            
+        }
+    ```
 
 - **Delete worker**
 
-cmd: `twinserver.k8s.delete_worker`
+    cmd: `twinserver.k8s.delete_worker`
 
-payload:
+    payload:
 
-```json
-{
-        "deployment_name": "sun199t2",
-        "name": "sun199t1worker5",
-    }
-```
+    ```json
+    {
+            "deployment_name": "sun199t2",
+            "name": "sun199t1worker5",
+        }
+    ```
 
 ### zdb
 
@@ -337,80 +337,80 @@ payload:
 
     payload:
 
-```json
-{
-        "name": "hamada",
-        "zdbs": [{
-            "name": "zdb1",
-            "node_id": 3,
-            "mode": "seq",
-            "disk_size": 10,
-            "public": true,
-            "password": "hamadaellol",
-        }, {
-            "name": "zdb2",
-            "node_id": 3,
-            "mode": "seq",
-            "disk_size": 10,
-            "public": true,
-            "password": "hamadaellol",
-        }],
-        "metadata": "",
-        "description": ""
-    }
-```
+    ```json
+    {
+            "name": "hamada",
+            "zdbs": [{
+                "name": "zdb1",
+                "node_id": 3,
+                "mode": "seq",
+                "disk_size": 10,
+                "public": true,
+                "password": "hamadaellol",
+            }, {
+                "name": "zdb2",
+                "node_id": 3,
+                "mode": "seq",
+                "disk_size": 10,
+                "public": true,
+                "password": "hamadaellol",
+            }],
+            "metadata": "",
+            "description": ""
+        }
+    ```
 
-**Note:** disk size in GB, zdb names should be different
+    > **Note:** disk size in GB, zdb names should be different
 
 - **List**
 
-cmd: `twinserver.zdbs.list`
+    cmd: `twinserver.zdbs.list`
 
-payload: `""`
+    payload: `""`
 
 - **Get**
 
-cmd: `twinserver.zdbs.get`
+    cmd: `twinserver.zdbs.get`
 
-payload: `{"name": "<deployment name>"}`
+    payload: `{"name": "<deployment name>"}`
 
 - **Delete**
 
-cmd: `twinserver.zdbs.delete`
+    cmd: `twinserver.zdbs.delete`
 
-payload: `{"name": "<deployment name>"}`
+    payload: `{"name": "<deployment name>"}`
 
 - **Add zdb**
 
-cmd: `twinserver.zdbs.add_zdb`
+    cmd: `twinserver.zdbs.add_zdb`
 
-payload:
+    payload:
 
-```json
-{
-        "deployment_name": "sun199t1",
-        "name": "hamada1",
-        "node_id": 2,
-        "mode": "seq",
-        "disk_size": 10,
-        "public": true,
-        "password": "hamada12345",
+    ```json
+    {
+            "deployment_name": "sun199t1",
+            "name": "hamada1",
+            "node_id": 2,
+            "mode": "seq",
+            "disk_size": 10,
+            "public": true,
+            "password": "hamada12345",
 
-    }
-```
+        }
+    ```
 
 - **Delete zdb**
 
-cmd: `twinserver.zdbs.delete_zdb`
+    cmd: `twinserver.zdbs.delete_zdb`
 
-payload:
+    payload:
 
-```json
-{
-        "deployment_name": "sun199t1",
-        "name": "hamada1",
-    }
-```
+    ```json
+    {
+            "deployment_name": "sun199t1",
+            "name": "hamada1",
+        }
+    ```
 
 ### QSFS Zdbs
 
@@ -420,163 +420,259 @@ payload:
 
     payload:
 
-```json
-{
-        "name": "hamada",
-        "count": 3,
-        "node_ids": [3, 5],
-        "disk_size": 10,
-        "password": "hamadaellol",
-        "metadata": "",
-        "description": ""
-    }
-```
+    ```json
+    {
+            "name": "hamada",
+            "count": 3,
+            "node_ids": [3, 5],
+            "disk_size": 10,
+            "password": "hamadaellol",
+            "metadata": "",
+            "description": ""
+        }
+    ```
 
-**Note:** disk size in GB
+    > **Note:** disk size in GB
 
 - **List**
 
-cmd: `twinserver.qsfs_zdbs.list`
+    cmd: `twinserver.qsfs_zdbs.list`
 
-payload: `""`
+    payload: `""`
 
 - **Get**
 
-cmd: `twinserver.qsfs_zdbs.get`
+    cmd: `twinserver.qsfs_zdbs.get`
 
-payload: `{"name": "<deployment name>"}`
+    payload: `{"name": "<deployment name>"}`
 
 - **Delete**
 
-cmd: `twinserver.qsfs_zdbs.delete`
+    cmd: `twinserver.qsfs_zdbs.delete`
 
-payload: `{"name": "<deployment name>"}`
+    payload: `{"name": "<deployment name>"}`
 
 ### Stellar
 
 - **Import**
-It will return the wallet address after importing the wallet and saving it.
+    It will return the wallet address after importing the wallet and saving it.
 
-cmd: `twinserver.stellar.import`
+    cmd: `twinserver.stellar.import`
 
-payload:
+    payload:
 
-```json
-{
-    "name": "mywallet",
-    "secret": "<wallet secret>",
-}
-```
+    ```json
+    {
+        "name": "mywallet",
+        "secret": "<wallet secret>",
+    }
+    ```
 
 - **Get**
-It will return the wallet address.
+    It will return the wallet address.
 
-cmd: `twinserver.stellar.get`
+    cmd: `twinserver.stellar.get`
 
-payload: `{"name": "<wallet name>"}`
+    payload: `{"name": "<wallet name>"}`
 
 - **Update**
-It will return the new wallet address after updating the wallet and saving it.
+    It will return the new wallet address after updating the wallet and saving it.
 
-cmd: `twinserver.stellar.update`
+    cmd: `twinserver.stellar.update`
 
-payload:
+    payload:
 
-```json
-{
-    "name": "mywallet",
-    "secret": "<wallet secret>",
-}
-```
+    ```json
+    {
+        "name": "mywallet",
+        "secret": "<wallet secret>",
+    }
+    ```
 
 - **Exists**
 
-cmd: `twinserver.stellar.exists`
+    cmd: `twinserver.stellar.exists`
 
-payload: `{"name": "<wallet name>"}`
+    payload: `{"name": "<wallet name>"}`
 
 - **List**
 
-cmd: `twinserver.stellar.list`
+    cmd: `twinserver.stellar.list`
 
-payload: `""`
+    payload: `""`
 
 - **Balance by name**
 
-cmd: `twinserver.stellar.balance_by_name`
+    cmd: `twinserver.stellar.balance_by_name`
 
-payload: `{"name": "<wallet name>"}`
+    payload: `{"name": "<wallet name>"}`
 
 - **Balance by address**
 
-cmd: `twinserver.stellar.balance_by_address`
+    cmd: `twinserver.stellar.balance_by_address`
 
-payload: `{"address": "<wallet name>"}`
+    payload: `{"address": "<wallet name>"}`
 
 - **Transfer**
 
-cmd: `twinserver.stellar.transfer`
+    cmd: `twinserver.stellar.transfer`
 
-payload:
+    payload:
 
-```json
-{
-    "name": "<wallet name>",
-    "target_address": "<target wallet address>",
-    "amount": 10,
-    "asset": "TFT",
-    "memo": "try1",
-}
-```
+    ```json
+    {
+        "name": "<wallet name>",
+        "target_address": "<target wallet address>",
+        "amount": 10,
+        "asset": "TFT",
+        "memo": "try1",
+    }
+    ```
 
 - **Delete**
 
-cmd: `twinserver.stellar.delete`
+    cmd: `twinserver.stellar.delete`
 
-payload: `{"name": "<wallet name>"}`
+    payload: `{"name": "<wallet name>"}`
 
 ### KVSotre
 
 - **Set**
 
-   cmd: `twinserver.kvstore.set`
+    cmd: `twinserver.kvstore.set`
 
-   payload: `'{"key": "<your key>", "value": "<key's value>"}'`
+    payload: `'{"key": "<your key>", "value": "<key's value>"}'`
 
 - **Get**
 
-   cmd: `twinserver.kvstore.get`
+    cmd: `twinserver.kvstore.get`
 
-   payload: `'{"key": "<your key>"}'`
+    payload: `'{"key": "<your key>"}'`
 
 - **List**
 
-   cmd: `twinserver.kvstore.list`
+    cmd: `twinserver.kvstore.list`
 
-   payload: `""`
+    payload: `""`
 
 - **Remove**
 
-   cmd: `twinserver.kvstore.remove`
+    cmd: `twinserver.kvstore.remove`
 
-   payload: `'{"key": "<your key>"}'`
+    payload: `'{"key": "<your key>"}'`
 
 ### Balance
 
 - **Get My Balance**
 
-   cmd: `twinserver.balance.getMyBalance`
+    cmd: `twinserver.balance.getMyBalance`
 
-   payload: `""`
+    payload: `""`
 
 - **Get**
 
-   cmd: `twinserver.balance.get`
+    cmd: `twinserver.balance.get`
 
-   payload: `'{"address": "<Substrate account address>"}'`
+    payload: `'{"address": "<Substrate account address>"}'`
 
 - **Transfer**
 
-   cmd: `twinserver.balance.transfer`
+    cmd: `twinserver.balance.transfer`
 
-   payload: `'{"address": "<Substrate account address>", "amount": 1}'`
+    payload: `'{"address": "<Substrate account address>", "amount": 1}'`
+
+### Capacity Planner
+
+- **Get Farms**
+
+    cmd: `twinserver.capacity.getFarms`
+
+    payload: `'{"page": <page number>, "maxResult": <result count per page>}'`
+
+    > **Note:** page, maxResult are optional with default values page: 1, maxResult: 50
+
+- **Get All Farms**
+
+    cmd: `twinserver.capacity.getAllFarms`
+
+    payload: `""`
+
+- **Get Nodes**
+
+    cmd: `twinserver.capacity.getNodes`
+
+    payload: `'{"page": <page number>, "maxResult": <result count per page>}'`
+
+    > **Note:** page, maxResult are optional with default values page: 1, maxResult: 50
+
+- **Get All Nodes**
+
+    cmd: `twinserver.capacity.getAllNodes`
+
+    payload: `""`
+
+- **Filter Nodes**
+
+    cmd: `twinserver.capacity.filterNodes`
+
+    payload:
+
+    ```json
+        {
+        "cru": <nodes with free cores>,
+        "mru": <nodes with free memory in GB>,
+        "sru": <node with free SSD storage in GB>,
+        "hru": <nodes with free HDD storage in GB>,
+        "publicIPs": <nodes in a farm with free public ips>,
+        "accessNodeV4": <nodes with public config for ipv4>,
+        "accessNodeV6": <nodes with public config for ipv6>,
+        "gateway": <nodes with domain>,
+        "farmId": <nodes in a farm with that farmId>,
+        "farmName": "<nodes in a farm with that farmId>",
+        "country": "<nodes in a specific country>",
+        "city": "<nodes in a specific city>"
+        }
+    ```
+
+    example:
+
+    ```json
+        {
+        "cru": 2,
+        "mru": 4,
+        "sru": 40,
+        "publicIPs": true,
+        "accessNodeV4": false,
+        "accessNodeV6": false,
+        "gateway": true,
+        "farmName": "freefarm",
+        }
+    ```
+
+    > **Notes:**
+    > All filter options are optional.
+    > It filters nodes with status(up or down) by default.
+
+- **Check Farm Has Free Public IPs**
+
+    cmd: `twinserver.capacity.CheckFarmHasFreePublicIps`
+
+    payload: `'{"farmId": 1}'`
+
+- **Get Nodes By FarmId**
+
+    cmd: `twinserver.capacity.getNodesByFarmId`
+
+    payload: `'{"farmId": 1}'`
+
+- **Get Node Free Resources**
+
+    cmd: `twinserver.capacity.getNodeFreeResources`
+
+    payload: `'{"nodeId": 7}'`
+
+- **Get FarmId From Farm Name**
+
+    cmd: `twinserver.capacity.getFarmIdFromFarmName`
+
+    payload: `'{"farmName": "freefarm"}'`

--- a/docs/server.md
+++ b/docs/server.md
@@ -4,6 +4,7 @@ Twin server is an [RMB](https://github.com/threefoldtech/go-rmb) server that exp
 
 ## Prerequisites
 
+- [Redis server](https://redis.io)
 - [RMB server](https://github.com/threefoldtech/go-rmb) should be installed and running
 
 ## Configuration
@@ -19,6 +20,16 @@ Add substrate url and account's mnemonics in `config.json` in [server directory]
     "keypairType": "sr25519" // keypair type for the account created on substrate
 }
 ```
+
+## Life cycle
+
+- User for the outside send an execution request(command with payload) to the RMB server.
+- RMB server puts this request in Redis.
+- Twin server checks if there is an execution request that its command is registered on the Twin server.
+- If this command is registered, the Twin server will pick up this request.
+- Twin server starts to execute it using the Grid3 client.
+- After finishing the execution, the Twin server puts the result back to Redis.
+- RMB keeps checking for the result is ready, and sends it back to the user once it's ready.
 
 ## Running
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -23,7 +23,7 @@ Add substrate url and account's mnemonics in `config.json` in [server directory]
 
 ## Life cycle
 
-- User for the outside send an execution request(command with payload) to the RMB server.
+- User from the outside sends an execution request(command with payload) to the RMB server.
 - RMB server puts this request in Redis.
 - Twin server checks if there is an execution request that its command is registered on the Twin server.
 - If this command is registered, the Twin server will pick up this request.

--- a/scripts/caprover_leader.ts
+++ b/scripts/caprover_leader.ts
@@ -1,9 +1,6 @@
-import "reflect-metadata";
-
-import { log } from "./utils";
-import { NetworkModel, MachineModel, MachinesModel, DiskModel } from "../src/modules/models";
 import { getClient } from "./client_loader";
-// import {generateString} from "../src/helpers/utils";
+import { NetworkModel, MachineModel, MachinesModel, DiskModel } from "../src";
+import { log } from "./utils";
 
 const CAPROVER_FLIST = "https://hub.grid.tf/tf-official-apps/tf-caprover-main.flist";
 // create network Object
@@ -34,7 +31,7 @@ vm.env = {
         "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDF7MKO2kjhnc3K02hsvJrMofIc8aploPsbPXzPZgeegd4sVJiGzdnTfiTjNUl7mdvct2FpoBBWQd9SeiLAW592CHMP9pOXO2CzOi/xNBrar7TnBc6nNnPjbd9bQEgLK9b2LQLCzLmZQmTWJolPETrkWcCLt4fmTchxHKROoRG6TOfAW2rieJSY8yj1+xtvjIHtFceD7vNByI62kOTzdlzOVmiGZ+9gkBJHSRTZkWniaACg0Mt3R9Xq6q6XHpIPTGqSOXeundPpaw+z+PUBc42Aa+LIgV2aoZP00yokx7WCttG3tS+xLv/6pEmIst5b/m4WNMkBx9fkGEIM4eaAH2mFXNc0bQNQJVqXEQSi7DWecWzNkHKDqRN6HoN/BAUF+clKW3fkvWme8iE8XK9xRCiNc8G3sQh2xIajKj0UbKn88k1fYMughJye93Q82mKXFw5QU3S0GzH/YoOEWhXUO8N76zZz+jyjYg9VBy/AU8lm1UJxAjiANIydkXjBFFofLh8= rafy@rafy-Inspiron-3576",
     SWM_NODE_MODE: "leader",
     CAPROVER_ROOT_DOMAIN: "rafy.grid.tf",
-    DEFAULT_PASSWORD: "captain42"
+    DEFAULT_PASSWORD: "captain42",
 };
 
 // create VMs Object
@@ -48,8 +45,8 @@ vms.description = "caprover leader machine/node";
 async function main() {
     const grid3 = await getClient();
 
-    // deploy vms
     try {
+        // deploy vms
         const res = await grid3.machines.deploy(vms);
         log(res);
 

--- a/scripts/caprover_worker.ts
+++ b/scripts/caprover_worker.ts
@@ -1,9 +1,6 @@
-import "reflect-metadata";
-
-import { log } from "./utils";
-import { NetworkModel, MachineModel, MachinesModel, DiskModel } from "../src/modules/models";
 import { getClient } from "./client_loader";
-// import {generateString} from "../src/helpers/utils";
+import { NetworkModel, MachineModel, MachinesModel, DiskModel } from "../src";
+import { log } from "./utils";
 
 const CAPROVER_FLIST = "https://hub.grid.tf/tf-official-apps/tf-caprover-main.flist";
 // create network Object
@@ -49,8 +46,8 @@ vms.description = "caprover worker machine/node";
 async function main() {
     const grid3 = await getClient();
 
-    // deploy vms
     try {
+        // deploy vms
         const res = await grid3.machines.deploy(vms);
         log(res);
 

--- a/scripts/client_loader.ts
+++ b/scripts/client_loader.ts
@@ -1,32 +1,30 @@
 import fs from "fs";
 import path from "path";
-import { GridClient } from "../src/client";
+import { env } from "process";
 
 import { MessageBusClientInterface } from "ts-rmb-client-base";
 import { HTTPMessageBusClient } from "ts-rmb-http-client";
 import { MessageBusClient } from "ts-rmb-redis-client";
-import { BackendStorageType } from "../src/storage/backend";
-import { KeypairType } from "../src/clients/tf-grid/client";
-import { env } from 'process';
 
-let network = env.NETWORK
-let mnemonic = env.MNEMONIC
-let rmb_proxy = env.RMB_PROXY
-let storeSecret = env.STORE_SECRET
+import { GridClient, BackendStorageType, KeypairType } from "../src";
+
+const network = env.NETWORK;
+const mnemonic = env.MNEMONIC;
+const rmb_proxy = env.RMB_PROXY;
+const storeSecret = env.STORE_SECRET;
 let config;
 
 if (network === undefined || mnemonic === undefined || rmb_proxy === undefined || storeSecret === undefined) {
-    console.log("Credentials not all found in env variables. Loading all credentials from default config.json...")
+    console.log("Credentials not all found in env variables. Loading all credentials from default config.json...");
     config = JSON.parse(fs.readFileSync(path.join(__dirname, "./config.json"), "utf-8"));
-}
-else {
-    console.log("Credentials loaded from env variables...")
+} else {
+    console.log("Credentials loaded from env variables...");
     config = {
-        "network": network,
-        "mnemonic": mnemonic,
-        "rmb_proxy": rmb_proxy,
-        "storeSecret": storeSecret
-    }
+        network: network,
+        mnemonic: mnemonic,
+        rmb_proxy: rmb_proxy,
+        storeSecret: storeSecret,
+    };
 }
 
 async function getClient(): Promise<GridClient> {

--- a/scripts/delete_all_contracts.ts
+++ b/scripts/delete_all_contracts.ts
@@ -1,12 +1,11 @@
-import { log } from "./utils";
-import "reflect-metadata";
 import { getClient } from "./client_loader";
-
+import { log } from "./utils";
 
 async function main() {
     const grid3 = await getClient();
 
-    grid3.contracts.cancelMyContracts()
+    grid3.contracts
+        .cancelMyContracts()
         .then(cancellation_res => {
             log(cancellation_res);
         })
@@ -16,7 +15,6 @@ async function main() {
         .finally(() => {
             grid3.disconnect();
         });
-
-};
+}
 
 main();

--- a/scripts/dynamic_single_vm.ts
+++ b/scripts/dynamic_single_vm.ts
@@ -1,14 +1,9 @@
-import "reflect-metadata";
-
-import { GridClient } from "../src/client";
-import { log } from "./utils";
-import { NetworkModel, MachineModel, MachinesModel, DiskModel, MachinesDeleteModel } from "../src/modules/models";
-import { Nodes, FilterOptions } from "../src/primitives";
 import { getClient } from "./client_loader";
+import { NetworkModel, MachineModel, MachinesModel, DiskModel, MachinesDeleteModel, FilterOptions } from "../src";
+import { log } from "./utils";
 
 async function main() {
     const grid3 = await getClient();
-    const nodes = new Nodes(GridClient.config.graphqlURL, GridClient.config.rmbClient["proxyURL"]);
 
     // create network Object
     const n = new NetworkModel();
@@ -31,8 +26,7 @@ async function main() {
     const vm = new MachineModel();
     vm.name = "testvm";
     try {
-        vm.node_id = +(await nodes.filterNodes(server1_options))[0].nodeId; // TODO: allow random choise
-
+        vm.node_id = +(await grid3.capacity.filterNodes(server1_options))[0].nodeId; // TODO: allow random choise
     } catch (err) {
         console.log(err);
         process.exit(1);
@@ -58,8 +52,8 @@ async function main() {
     vms.metadata = "{'testVMs': true}";
     vms.description = "test deploying VMs via ts grid3 client";
 
-    // deploy vms
     try {
+        // deploy vms
         const res = await grid3.machines.deploy(vms);
         log(res);
 
@@ -70,15 +64,12 @@ async function main() {
         // // delete
         // const d = await grid3.machines.delete({ name: vms.name });
         // log(d);
-    }
-    catch (err) {
+    } catch (err) {
         console.log(err);
         process.exit(1);
-    }
-    finally {
+    } finally {
         grid3.disconnect();
     }
-
 }
 
 main();

--- a/scripts/fqdn_gateway.ts
+++ b/scripts/fqdn_gateway.ts
@@ -1,8 +1,6 @@
-import "reflect-metadata";
-
-import { log } from "./utils";
-import { GatewayFQDNModel, GatewayFQDNDeleteModel } from "../src/modules/models";
 import { getClient } from "./client_loader";
+import { GatewayFQDNModel, GatewayFQDNDeleteModel } from "../src";
+import { log } from "./utils";
 
 // read more about the gateway types in this doc: https://github.com/threefoldtech/zos/tree/main/docs/gateway
 

--- a/scripts/kubernetes.ts
+++ b/scripts/kubernetes.ts
@@ -1,8 +1,6 @@
-import "reflect-metadata";
-
-import { log } from "./utils";
-import { NetworkModel, K8SModel, KubernetesNodeModel } from "../src/modules/models";
 import { getClient } from "./client_loader";
+import { NetworkModel, K8SModel, KubernetesNodeModel } from "../src";
+import { log } from "./utils";
 
 // create network Object
 const n = new NetworkModel();
@@ -55,16 +53,12 @@ async function main() {
         // // delete
         // const d = await grid3.k8s.delete({ name: k.name });
         // log(d);
-    }
-    catch (err) {
+    } catch (err) {
         console.log(err);
         process.exit(1);
-    }
-    finally {
+    } finally {
         grid3.disconnect();
     }
-
-
 }
 
 main();

--- a/scripts/kubernetes_with_qsfs.ts
+++ b/scripts/kubernetes_with_qsfs.ts
@@ -1,8 +1,6 @@
-import "reflect-metadata";
-
-import { log } from "./utils";
-import { NetworkModel, K8SModel, KubernetesNodeModel, K8SDeleteModel } from "../src/modules/models";
 import { getClient } from "./client_loader";
+import { NetworkModel, K8SModel, KubernetesNodeModel, K8SDeleteModel } from "../src";
+import { log } from "./utils";
 
 const qsfs_name = "testQsfsK8sq1";
 
@@ -15,7 +13,7 @@ const qsfs = {
     disk_size: 10,
     description: "my qsfs test",
     metadata: "",
-}
+};
 
 // create network Object
 const n = new NetworkModel();
@@ -91,15 +89,12 @@ async function main() {
         // log(d);
         // const r = await grid3.qsfs_zdbs.delete({ name: qsfs_name });
         // log(r);
-    }
-    catch (err) {
+    } catch (err) {
         console.log(err);
         process.exit(1);
-    }
-    finally {
+    } finally {
         grid3.disconnect();
     }
-
 }
 
 main();

--- a/scripts/kvstore_example.ts
+++ b/scripts/kvstore_example.ts
@@ -1,12 +1,5 @@
-import "reflect-metadata";
-
-import { log } from "./utils";
 import { getClient } from "./client_loader";
-
-const exampleObj = {
-    key1: "value1",
-    key2: 2,
-};
+import { log } from "./utils";
 
 /*
 KVStore example usage:
@@ -23,7 +16,10 @@ async function main() {
 
     // set key
     const key = "hamada";
-
+    const exampleObj = {
+        key1: "value1",
+        key2: 2,
+    };
     try {
         // set key
         await db.set({ key, value: JSON.stringify(exampleObj) });
@@ -38,15 +34,12 @@ async function main() {
 
         // remove the key
         await db.remove({ key });
-    }
-    catch (err) {
+    } catch (err) {
         console.log(err);
         process.exit(1);
-    }
-    finally {
+    } finally {
         gridClient.disconnect();
     }
-
 }
 
 main();

--- a/scripts/multiple_vms.ts
+++ b/scripts/multiple_vms.ts
@@ -1,8 +1,6 @@
-import "reflect-metadata";
-
-import { log } from "./utils";
-import { NetworkModel, MachineModel, MachinesModel, DiskModel, MachinesDeleteModel } from "../src/modules/models";
 import { getClient } from "./client_loader";
+import { NetworkModel, MachineModel, MachinesModel, DiskModel, MachinesDeleteModel } from "../src";
+import { log } from "./utils";
 
 // create network Object
 const n = new NetworkModel();
@@ -66,8 +64,8 @@ vms.description = "test deploying VMs via ts grid3 client";
 async function main() {
     const grid3 = await getClient();
 
-    // deploy vms
     try {
+        // deploy vms
         const res = await grid3.machines.deploy(vms);
         log(res);
 
@@ -78,16 +76,12 @@ async function main() {
         // // delete
         // const d = await grid3.machines.delete({ name: vms.name });
         // log(d);
-    }
-    catch (err) {
+    } catch (err) {
         console.log(err);
         process.exit(1);
-    }
-    finally {
+    } finally {
         grid3.disconnect();
     }
-
-
 }
 
 main();

--- a/scripts/name_gateway.ts
+++ b/scripts/name_gateway.ts
@@ -1,8 +1,6 @@
-import "reflect-metadata";
-
-import { log } from "./utils";
-import { GatewayNameModel, GatewayNameDeleteModel } from "../src/modules/models";
 import { getClient } from "./client_loader";
+import { GatewayNameModel, GatewayNameDeleteModel } from "../src";
+import { log } from "./utils";
 
 // read more about the gateway types in this doc: https://github.com/threefoldtech/zos/tree/main/docs/gateway
 

--- a/scripts/single_vm.ts
+++ b/scripts/single_vm.ts
@@ -1,8 +1,6 @@
-import "reflect-metadata";
-
-import { log } from "./utils";
-import { NetworkModel, MachineModel, MachinesModel, DiskModel, MachinesDeleteModel } from "../src/modules/models";
 import { getClient } from "./client_loader";
+import { NetworkModel, MachineModel, MachinesModel, DiskModel, MachinesDeleteModel } from "../src";
+import { log } from "./utils";
 
 // create network Object
 const n = new NetworkModel();
@@ -43,8 +41,8 @@ vms.description = "test deploying VMs via ts grid3 client";
 async function main() {
     const grid3 = await getClient();
 
-    // deploy vms
     try {
+        // deploy vms
         const res = await grid3.machines.deploy(vms);
         log(res);
 
@@ -55,17 +53,12 @@ async function main() {
         // // delete
         // const d = await grid3.machines.delete({ name: vms.name });
         // log(d);
-    }
-    catch (err) {
+    } catch (err) {
         console.log(err);
         process.exit(1);
-    }
-    finally {
+    } finally {
         grid3.disconnect();
     }
-
-
-};
-
+}
 
 main();

--- a/scripts/test_node_filters.ts
+++ b/scripts/test_node_filters.ts
@@ -1,33 +1,27 @@
-import "reflect-metadata";
-
-import { log } from "./utils";
-import { GridClient } from "../src/client";
-import { Nodes } from "../src/primitives";
-
 import { getClient } from "./client_loader";
+import { log } from "./utils";
 
 async function main() {
     const grid3 = await getClient();
-    const nodes = new Nodes(GridClient.config.graphqlURL, GridClient.config.rmbClient["proxyURL"]);
     try {
         log("getFarms");
-        const f = await nodes.getFarms();
+        const f = await grid3.capacity.getFarms();
         log(f);
 
         log("getNodes");
-        const n = await nodes.getNodes();
+        const n = await grid3.capacity.getNodes();
         log(n);
 
-        log("getNodesByFarmID(2)");
-        const z = await nodes.getNodesByFarmID(1);
+        log("getNodesByFarmID(1)");
+        const z = await grid3.capacity.getNodesByFarmId({ farmId: 1 });
         log(z);
 
-        log("freeCapacity(64)");
-        const c = await nodes.freeCapacity(1);
+        log("NodeFreeResources(1)");
+        const c = await grid3.capacity.getNodeFreeResources({ nodeId: 1 });
         log(c);
 
         log("filterNodes");
-        const x = await nodes.filterNodes({
+        const x = await grid3.capacity.filterNodes({
             country: "Belgium",
             publicIPs: true,
             cru: 20,

--- a/scripts/vm_with_qsfs.ts
+++ b/scripts/vm_with_qsfs.ts
@@ -1,12 +1,11 @@
-import "reflect-metadata";
-
-import { log } from "./utils";
 import { getClient } from "./client_loader";
+import { MachinesModel, QSFSZDBSModel } from "../src";
+import { log } from "./utils";
 
 const qsfs_name = "wed2710q1";
 const machines_name = "wed2710t1";
 
-const qsfs = {
+const qsfs: QSFSZDBSModel = {
     name: qsfs_name,
     count: 8,
     node_ids: [16, 17],
@@ -14,9 +13,9 @@ const qsfs = {
     disk_size: 10,
     description: "my qsfs test",
     metadata: "",
-}
+};
 
-const vms = {
+const vms: MachinesModel = {
     name: machines_name,
     network: {
         name: "wed2710n1",
@@ -60,8 +59,7 @@ const vms = {
     ],
     metadata: "{'testVMs': true}",
     description: "test deploying VMs via ts grid3 client",
-}
-
+};
 
 async function cancel(grid3) {
     // delete
@@ -89,15 +87,12 @@ async function main() {
         log(l);
 
         // await cancel(grid3);
-    }
-    catch (err) {
+    } catch (err) {
         console.log(err);
         process.exit(1);
-    }
-    finally {
+    } finally {
         grid3.disconnect();
     }
-
 }
 
 main();

--- a/scripts/zdb.ts
+++ b/scripts/zdb.ts
@@ -1,9 +1,6 @@
-import "reflect-metadata";
-
-import { log } from "./utils";
-import { ZDBModel, ZDBSModel, ZDBDeleteModel } from "../src/modules/models";
-import { ZdbModes } from "../src/zos/zdb";
 import { getClient } from "./client_loader";
+import { ZdbModes, ZDBModel, ZDBSModel, ZDBDeleteModel } from "../src";
+import { log } from "./utils";
 
 // create zdb object
 const zdb = new ZDBModel();
@@ -22,8 +19,8 @@ zdbs.metadata = '{"test": "test"}';
 
 async function main() {
     const grid3 = await getClient();
-    // deploy zdb
     try {
+        // deploy zdb
         const res = await grid3.zdbs.deploy(zdbs);
         log(res);
 
@@ -34,16 +31,12 @@ async function main() {
         // // delete
         // const d = await grid3.zdbs.delete({ name: zdbs.name });
         // log(d);
-    }
-    catch (err) {
+    } catch (err) {
         console.log(err);
         process.exit(1);
-    }
-    finally {
+    } finally {
         grid3.disconnect();
     }
-
-
 }
 
 main();

--- a/src/client.ts
+++ b/src/client.ts
@@ -32,7 +32,7 @@ class GridClient {
         public backendStorageType: BackendStorageType = BackendStorageType.auto,
         public keypairType: KeypairType = KeypairType.sr25519,
     ) {}
-    async connect() {
+    async connect(): Promise<void> {
         const urls = this.getDefaultUrls(this.network);
         const tfclient = new TFClient(urls.substrate, this.mnemonic, this.storeSecret, this.keypairType);
         await tfclient.connect();
@@ -45,7 +45,7 @@ class GridClient {
         this.twinId = await tfclient.twins.getMyTwinId();
         this._connect();
     }
-    _connect() {
+    _connect(): void {
         const urls = this.getDefaultUrls(this.network);
         this.rmbClient["twinId"] = this.twinId;
         this.rmbClient["proxyURL"] = urls.rmbProxy;
@@ -71,7 +71,7 @@ class GridClient {
         }
     }
 
-    getDefaultUrls(network: NetworkEnv) {
+    getDefaultUrls(network: NetworkEnv): Record<string, string> {
         const urls = { rmbProxy: "", substrate: "", graphql: "" };
         if (network === NetworkEnv.dev) {
             urls.rmbProxy = "https://gridproxy.dev.grid.tf";
@@ -85,7 +85,7 @@ class GridClient {
         return urls;
     }
 
-    disconnect() {
+    disconnect(): void {
         console.log("disconnecting");
         for (const key of Object.keys(TFClient.clients)) {
             TFClient.clients[key].disconnect();

--- a/src/client.ts
+++ b/src/client.ts
@@ -20,6 +20,7 @@ class GridClient {
     twins: modules.twins;
     kvstore: modules.kvstore;
     balance: modules.balance;
+    capacity: modules.capacity;
     twinId: number;
 
     constructor(

--- a/src/modules/capacity.ts
+++ b/src/modules/capacity.ts
@@ -1,0 +1,42 @@
+import { expose } from "../helpers/expose";
+import { GridClientConfig } from "../config";
+import { validateInput } from "../helpers/validator";
+import { Nodes, FilterOptions } from "../primitives/nodes";
+import { FarmsGetModel, NodesGetModel } from "./models";
+
+
+class Capacity {
+    nodes: Nodes;
+    constructor(config: GridClientConfig) {
+        this.nodes = new Nodes(config.graphqlURL, config.rmbClient["proxyURL"]);
+    }
+    @expose
+    @validateInput
+    async getFarms(options?: FarmsGetModel) {
+        return await this.nodes.getFarms(options.page, options.max_result);
+    }
+
+    @expose
+    @validateInput
+    async getNodes(options?: NodesGetModel) {
+        return await this.nodes.getNodes(options.page, options.max_result);
+    }
+
+    @expose
+    async getAllFarms() {
+        return await this.nodes.getAllFarms();
+    }
+
+    @expose
+    async getAllNodes() {
+        return await this.nodes.getAllNodes();
+    }
+
+    @expose
+    @validateInput
+    async filterNodes(options?: FilterOptions) {
+        return await this.nodes.filterNodes(options);
+    }
+}
+
+export { Capacity as capacity };

--- a/src/modules/capacity.ts
+++ b/src/modules/capacity.ts
@@ -46,8 +46,8 @@ class Capacity {
 
     @expose
     @validateInput
-    async CheckFarmHasFreePublicIps(options?: FarmHasFreePublicIPsModel): Promise<boolean> {
-        return await this.nodes.CheckFarmHasFreePublicIps(options.farmId);
+    async checkFarmHasFreePublicIps(options?: FarmHasFreePublicIPsModel): Promise<boolean> {
+        return await this.nodes.checkFarmHasFreePublicIps(options.farmId);
     }
 
     @expose

--- a/src/modules/capacity.ts
+++ b/src/modules/capacity.ts
@@ -19,13 +19,13 @@ class Capacity {
     @expose
     @validateInput
     async getFarms(options: FarmsGetModel = {}): Promise<FarmInfo[]> {
-        return await this.nodes.getFarms(options.page, options.max_result);
+        return await this.nodes.getFarms(options.page, options.maxResult);
     }
 
     @expose
     @validateInput
     async getNodes(options: NodesGetModel = {}): Promise<NodeInfo[]> {
-        return await this.nodes.getNodes(options.page, options.max_result);
+        return await this.nodes.getNodes(options.page, options.maxResult);
     }
 
     @expose

--- a/src/modules/capacity.ts
+++ b/src/modules/capacity.ts
@@ -1,9 +1,15 @@
 import { expose } from "../helpers/expose";
 import { GridClientConfig } from "../config";
 import { validateInput } from "../helpers/validator";
-import { Nodes, FilterOptions } from "../primitives/nodes";
-import { FarmsGetModel, NodesGetModel } from "./models";
-
+import { Nodes, FilterOptions, FarmInfo, NodeInfo, NodeResources } from "../primitives/nodes";
+import {
+    FarmsGetModel,
+    NodesGetModel,
+    FarmHasFreePublicIPsModel,
+    NodesByFarmIdModel,
+    NodeFreeResourcesModel,
+    FarmIdFromFarmNameModel,
+} from "./models";
 
 class Capacity {
     nodes: Nodes;
@@ -12,30 +18,54 @@ class Capacity {
     }
     @expose
     @validateInput
-    async getFarms(options?: FarmsGetModel) {
+    async getFarms(options?: FarmsGetModel): Promise<FarmInfo[]> {
         return await this.nodes.getFarms(options.page, options.max_result);
     }
 
     @expose
     @validateInput
-    async getNodes(options?: NodesGetModel) {
+    async getNodes(options?: NodesGetModel): Promise<NodeInfo[]> {
         return await this.nodes.getNodes(options.page, options.max_result);
     }
 
     @expose
-    async getAllFarms() {
+    async getAllFarms(): Promise<FarmInfo[]> {
         return await this.nodes.getAllFarms();
     }
 
     @expose
-    async getAllNodes() {
+    async getAllNodes(): Promise<NodeInfo[]> {
         return await this.nodes.getAllNodes();
     }
 
     @expose
     @validateInput
-    async filterNodes(options?: FilterOptions) {
+    async filterNodes(options?: FilterOptions): Promise<NodeInfo[]> {
         return await this.nodes.filterNodes(options);
+    }
+
+    @expose
+    @validateInput
+    async CheckFarmHasFreePublicIps(options?: FarmHasFreePublicIPsModel): Promise<boolean> {
+        return await this.nodes.CheckFarmHasFreePublicIps(options.farmId);
+    }
+
+    @expose
+    @validateInput
+    async getNodesByFarmId(options?: NodesByFarmIdModel): Promise<NodeInfo[]> {
+        return await this.nodes.getNodesByFarmId(options.farmId);
+    }
+
+    @expose
+    @validateInput
+    async getNodeFreeResources(options?: NodeFreeResourcesModel): Promise<NodeResources> {
+        return await this.nodes.getNodeFreeResources(options.nodeId);
+    }
+
+    @expose
+    @validateInput
+    async getFarmIdFromFarmName(options?: FarmIdFromFarmNameModel): Promise<number> {
+        return await this.nodes.getFarmIdFromFarmName(options.farmName);
     }
 }
 

--- a/src/modules/capacity.ts
+++ b/src/modules/capacity.ts
@@ -18,13 +18,13 @@ class Capacity {
     }
     @expose
     @validateInput
-    async getFarms(options?: FarmsGetModel): Promise<FarmInfo[]> {
+    async getFarms(options: FarmsGetModel = {}): Promise<FarmInfo[]> {
         return await this.nodes.getFarms(options.page, options.max_result);
     }
 
     @expose
     @validateInput
-    async getNodes(options?: NodesGetModel): Promise<NodeInfo[]> {
+    async getNodes(options: NodesGetModel = {}): Promise<NodeInfo[]> {
         return await this.nodes.getNodes(options.page, options.max_result);
     }
 

--- a/src/modules/contracts.ts
+++ b/src/modules/contracts.ts
@@ -1,5 +1,3 @@
-import { MessageBusClientInterface } from "ts-rmb-client-base";
-
 import { TFClient } from "../clients/tf-grid/client";
 import {
     NodeContractCreateModel,

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -8,5 +8,6 @@ export * from "./contracts";
 export * from "./twins";
 export * from "./kvstore";
 export * from "./balance";
+export * from "./capacity";
 export * from "./stellar";
 export * from "./zos";

--- a/src/modules/machines.ts
+++ b/src/modules/machines.ts
@@ -1,6 +1,6 @@
 import { Addr } from "netaddr";
 
-import { WorkloadTypes, Workload } from "../zos/workload";
+import { WorkloadTypes } from "../zos/workload";
 
 import { BaseModule } from "./base";
 import { MachinesModel, MachinesDeleteModel, MachinesGetModel, AddMachineModel, DeleteMachineModel } from "./models";

--- a/src/modules/models.ts
+++ b/src/modules/models.ts
@@ -295,6 +295,13 @@ class WalletDeleteModel {
 
 class WalletGetModel extends WalletDeleteModel {}
 
+class FarmsGetModel {
+    @Expose() @IsInt() @Min(1) @IsOptional() page?: number; // default 1
+    @Expose() @IsInt() @Min(1) @IsOptional() max_result?: number; // default 50
+}
+
+class NodesGetModel extends FarmsGetModel {}
+
 export {
     DiskModel,
     NetworkModel,
@@ -352,4 +359,6 @@ export {
     GatewayFQDNDeleteModel,
     GatewayNameGetModel,
     GatewayNameDeleteModel,
+    FarmsGetModel,
+    NodesGetModel,
 };

--- a/src/modules/models.ts
+++ b/src/modules/models.ts
@@ -302,6 +302,20 @@ class FarmsGetModel {
 
 class NodesGetModel extends FarmsGetModel {}
 
+class FarmHasFreePublicIPsModel {
+    @Expose() @IsInt() @Min(1) farmId: number;
+}
+
+class NodesByFarmIdModel extends FarmHasFreePublicIPsModel {}
+
+class NodeFreeResourcesModel {
+    @Expose() @IsInt() @Min(1) nodeId: number;
+}
+
+class FarmIdFromFarmNameModel {
+    @Expose() @IsString() @IsNotEmpty() farmName: string;
+}
+
 export {
     DiskModel,
     NetworkModel,
@@ -361,4 +375,8 @@ export {
     GatewayNameDeleteModel,
     FarmsGetModel,
     NodesGetModel,
+    FarmHasFreePublicIPsModel,
+    NodesByFarmIdModel,
+    NodeFreeResourcesModel,
+    FarmIdFromFarmNameModel,
 };

--- a/src/modules/models.ts
+++ b/src/modules/models.ts
@@ -297,7 +297,7 @@ class WalletGetModel extends WalletDeleteModel {}
 
 class FarmsGetModel {
     @Expose() @IsInt() @Min(1) @IsOptional() page?: number; // default 1
-    @Expose() @IsInt() @Min(1) @IsOptional() max_result?: number; // default 50
+    @Expose() @IsInt() @Min(1) @IsOptional() maxResult?: number; // default 50
 }
 
 class NodesGetModel extends FarmsGetModel {}

--- a/src/primitives/nodes.ts
+++ b/src/primitives/nodes.ts
@@ -153,7 +153,7 @@ class Nodes {
         return await this.getFarms(1, farmsCount, url);
     }
 
-    async CheckFarmHasFreePublicIps(farmId: number, farms: FarmInfo[] = null, url = ""): Promise<boolean> {
+    async checkFarmHasFreePublicIps(farmId: number, farms: FarmInfo[] = null, url = ""): Promise<boolean> {
         if (!farms) {
             farms = await this.getAllFarms(url);
         }
@@ -233,7 +233,7 @@ class Nodes {
             (options.gateway && !hasDomain) ||
             (options.farmId && options.farmId !== node.farmId) ||
             (options.farmName && (await this.getFarmIdFromFarmName(options.farmName, farms)) !== +node.farmId) ||
-            (options.publicIPs && !(await this.CheckFarmHasFreePublicIps(+node.farmId, farms)))
+            (options.publicIPs && !(await this.checkFarmHasFreePublicIps(+node.farmId, farms)))
         ) {
             node["valid"] = false;
             return node;

--- a/src/primitives/nodes.ts
+++ b/src/primitives/nodes.ts
@@ -178,11 +178,12 @@ class Nodes {
     }
 
     async getNodesByFarmID(farmId: number, url = "") {
+        const nodesCount = this.gqlClient.getItemTotalCount("nodes", `(where: {farmId_eq: ${farmId}})`);
         let r: string;
         if (url) r = url;
         else r = this.proxyURL;
 
-        return send("get", `${r}/nodes?farm_id=${farmId}`, "", {})
+        return send("get", `${r}/nodes?farm_id=${farmId}&max_result=${nodesCount}`, "", {})
             .then(res => {
                 if (res) return res;
                 else throw new Error(`The farm with id ${farmId}: doesn't have any nodes`);
@@ -253,7 +254,7 @@ class Nodes {
         return node;
     }
 
-    async filterNodes(options: FilterOptions, url = ""): Promise<NodeInfo[]> {
+    async filterNodes(options: FilterOptions = {}, url = ""): Promise<NodeInfo[]> {
         options = plainToClass(FilterOptions, options, { excludeExtraneousValues: true });
         await validateObject(options);
         const farms = await this.getAllFarms(url);
@@ -276,7 +277,7 @@ class Nodes {
      * Get farm id from farm name.
      * It returns 0 in case the farm name is not found.
      * @param  {string} name
-     * @returns Promise<number>
+     * @returns {Promise<number>}
      */
     async getFarmIdFromFarmName(name: string, farms: FarmInfo[] = null, url = ""): Promise<number> {
         if (!farms) {

--- a/src/primitives/nodes.ts
+++ b/src/primitives/nodes.ts
@@ -134,12 +134,12 @@ class Nodes {
         return GB * 1024 * 1024 * 1024;
     }
 
-    async getFarms(page = 1, max_result = 50, url = ""): Promise<FarmInfo[]> {
+    async getFarms(page = 1, maxResult = 50, url = ""): Promise<FarmInfo[]> {
         let r: string;
         if (url) r = url;
         else r = this.proxyURL;
 
-        return send("get", `${r}/farms?page=${page}&max_result=${max_result}`, "", {})
+        return send("get", `${r}/farms?page=${page}&max_result=${maxResult}`, "", {})
             .then(res => {
                 return res["data"]["farms"];
             })
@@ -163,12 +163,12 @@ class Nodes {
             .includes(farmId);
     }
 
-    async getNodes(page = 1, max_result = 50, url = ""): Promise<NodeInfo[]> {
+    async getNodes(page = 1, maxResult = 50, url = ""): Promise<NodeInfo[]> {
         let r: string;
         if (url) r = url;
         else r = this.proxyURL;
 
-        const ret = await send("get", `${r}/nodes?page=${page}&max_result=${max_result}`, "", {});
+        const ret = await send("get", `${r}/nodes?page=${page}&max_result=${maxResult}`, "", {});
         return ret;
     }
 
@@ -260,8 +260,6 @@ class Nodes {
     }
 
     async filterNodes(options: FilterOptions = {}, url = ""): Promise<NodeInfo[]> {
-        options = plainToClass(FilterOptions, options, { excludeExtraneousValues: true });
-        await validateObject(options);
         const farms = await this.getAllFarms(url);
         return await this.getAllNodes(url)
             .then(nodes => {


### PR DESCRIPTION
### Description

- Add capacity methods on the modules to be exposed as well on the twin server.
- Add twin server life cycle.
- Update capacity planner script to use the exposed capacity module.
- Update the scripts to not import reflect metadata and format them.
- Add scripts to lint workflow
- Update docs with the new capacity module and format them.

### Related issues

- #74 