### PR TITLE
Fix resources' query units

### DIFF
--- a/src/primitives/network.ts
+++ b/src/primitives/network.ts
@@ -455,7 +455,7 @@ class Network {
         } catch (e) {
             throw Error(`Couldn't get free Wireguard ports for node ${node_id} due to ${e}`);
         }
-        events.emit("logs", `Node ${node_id} reserved ports: ${result}`);
+        events.emit("logs", `Node ${node_id} reserved ports: ${JSON.stringify(result)}`);
 
         let port = 0;
         while (!port || result.includes(port)) {
@@ -480,7 +480,7 @@ class Network {
         } catch (e) {
             console.log(`Couldn't get public config for node ${node_id} due to ${e}`);
         }
-        events.emit("logs", `Node ${node_id} public config: ${result}`);
+        events.emit("logs", `Node ${node_id} public config: ${JSON.stringify(result)}`);
 
         let endpoint;
         if (result) {
@@ -498,7 +498,7 @@ class Network {
         } catch (e) {
             throw Error(`Couldn't get the network interfaces for node ${node_id} due to ${e}`);
         }
-        events.emit("logs", `Node ${node_id} network interfaces: ${result}`);
+        events.emit("logs", `Node ${node_id} network interfaces: ${JSON.stringify(result)}`);
 
         if (result) {
             for (const iface of Object.keys(result)) {

--- a/src/primitives/nodes.ts
+++ b/src/primitives/nodes.ts
@@ -240,9 +240,9 @@ class Nodes {
     getUrlQuery(options: FilterOptions = {}) {
         const params = {
             free_cru: options.cru,
-            free_mru: options.mru,
-            free_sru: options.sru,
-            free_hru: options.hru,
+            free_mru: Math.ceil(this._g2b(options.mru)) || 0,
+            free_sru: Math.ceil(this._g2b(options.sru)) || 0,
+            free_hru: Math.ceil(this._g2b(options.hru)) || 0,
             free_ips: options.publicIPs ? 1 : 0,
             ipv4: options.accessNodeV4,
             ipv6: options.accessNodeV6,


### PR DESCRIPTION
### Changes
- Convert the resources' queries to be with GB.
- Fix logs that contain `[object]` 

### Related issues
- #246 