### PR TITLE
Fix workload's version on updating and waiting to be ready

### DIFF
--- a/src/high_level/twinDeploymentHandler.ts
+++ b/src/high_level/twinDeploymentHandler.ts
@@ -140,9 +140,14 @@ class TwinDeploymentHandler {
                 continue;
             }
             let readyWorkloads = 0;
-            for (let i = 0; i < deployment.workloads.length; i++) {
-                if (this.checkWorkload(deployment.workloads[i], twinDeployment.deployment.workloads[i], node_id)) {
-                    readyWorkloads += 1;
+            for (const workload of deployment.workloads) {
+                for (const w of twinDeployment.deployment.workloads) {
+                    if (w.name === workload.name) {
+                        if (this.checkWorkload(workload, w, node_id)) {
+                            readyWorkloads += 1;
+                        }
+                        break;
+                    }
                 }
             }
             if (readyWorkloads === twinDeployment.deployment.workloads.length) {

--- a/src/modules/base.ts
+++ b/src/modules/base.ts
@@ -93,6 +93,15 @@ class BaseModule {
         return (await this._list()).includes(name);
     }
 
+    workloadExists(name: string, oldDeployment: Deployment[]): boolean {
+        for (const deployment of oldDeployment) {
+            for (const workload of deployment.workloads) {
+                if (name === workload.name) return true;
+            }
+        }
+        return false;
+    }
+
     async _getDeploymentNodeIds(name: string): Promise<number[]> {
         const nodeIds = [];
         const contracts = await this.getDeploymentContracts(name);

--- a/src/modules/k8s.ts
+++ b/src/modules/k8s.ts
@@ -232,6 +232,10 @@ class K8sModule extends BaseModule {
             throw Error(`There is no k8s deployment with the name: ${options.deployment_name}`);
         }
         const oldDeployments = await this._get(options.deployment_name);
+        if (this.workloadExists(options.name, oldDeployments))
+            throw Error(
+                `There is another worker with the same name "${options.name}" in this cluster ${options.deployment_name}`,
+            );
         const masterWorkloads = await this._getMastersWorkload(options.deployment_name, oldDeployments);
         if (masterWorkloads.length === 0) {
             throw Error("Couldn't get master node");

--- a/src/modules/machines.ts
+++ b/src/modules/machines.ts
@@ -133,6 +133,10 @@ class MachinesModule extends BaseModule {
             throw Error(`There are no machine deployments with the name: ${options.deployment_name}`);
         }
         const oldDeployments = await this._get(options.deployment_name);
+        if (this.workloadExists(options.name, oldDeployments))
+            throw Error(
+                `There is another machine with the same name "${options.name}" in the same deployment ${options.deployment_name}`,
+            );
         const workload = (
             await this._getWorkloadsByTypes(options.deployment_name, oldDeployments, [WorkloadTypes.zmachine])
         )[0];

--- a/src/modules/zdb.ts
+++ b/src/modules/zdb.ts
@@ -113,6 +113,10 @@ class ZdbsModule extends BaseModule {
             throw Error(`There is no zdb deployment with name: ${options.deployment_name}`);
         }
         const oldDeployments = await this._get(options.deployment_name);
+        if (this.workloadExists(options.name, oldDeployments))
+            throw Error(
+                `There is another zdb with the same name "${options.name}" in this deployment ${options.deployment_name}`,
+            );
         const twinDeployment = await this.zdb.create(
             options.name,
             options.node_id,

--- a/src/primitives/deployment.ts
+++ b/src/primitives/deployment.ts
@@ -74,8 +74,7 @@ class DeploymentFactory {
                 if (w.name !== workload.name) {
                     continue;
                 }
-                const oldVersion = workload.version;
-                workload.version = 0;
+                w.version = workload.version;
                 // Don't change the machine ip
                 if (w.type === WorkloadTypes.zmachine) {
                     const nodes = new Nodes(this.config.graphqlURL, this.config.rmbClient["proxyURL"]);
@@ -91,7 +90,6 @@ class DeploymentFactory {
                     }
                 }
                 if (w.challenge() === workload.challenge()) {
-                    workload.version = oldVersion;
                     continue;
                 }
                 workload.version = deploymentVersion + 1;


### PR DESCRIPTION
### Description

this issue happens when adding another workload on the same deployment 2 times in series, as the version after the second update becomes 2 and the client reset the workload version while updating, so the chagelleng is changed for the version's change. To solve this, the version should be the same while comparing the challenges of the old and new workloads.

the other issue is while waiting for the deployment to be ready, the deployment workloads wasn't sorted, so that was fixed by checking their names before checking their versions

### Related issues

- #300 
- https://github.com/threefoldtech/grid_weblets/issues/832