### PR TITLE
update metadata when updating node in adding workers

### DIFF
--- a/src/high_level/twinDeploymentHandler.ts
+++ b/src/high_level/twinDeploymentHandler.ts
@@ -71,11 +71,12 @@ class TwinDeploymentHandler {
 
     async update(deployment: Deployment) {
         // TODO: update the contract with public when it is available
+        const old_contract = await this.tfclient.contracts.get(deployment.contract_id);
         let contract;
         try {
             contract = await this.tfclient.contracts.updateNode(
                 deployment.contract_id,
-                "",
+                old_contract["contractType"]["nodeContract"]["deploymentData"],
                 deployment.challenge_hash(),
             );
             events.emit("logs", `Contract with id: ${contract["contractId"]} has been updated`);


### PR DESCRIPTION
### Description

- master metadata is removed when adding new workers 

### Changes

- added metadata while updating the node

### Related Issues

- https://github.com/threefoldtech/grid3_client_ts/issues/327